### PR TITLE
Add initial production build pipeline and integration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 .vscode
 .yarn
 build
+dist
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # package logs
 npm-debug.log*

--- a/bin/prepare-a8c-deploy.js
+++ b/bin/prepare-a8c-deploy.js
@@ -2,82 +2,133 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 
-const createReactAppOutputDirectory = path.resolve( __dirname, '..', 'build' );
+/* 
+Create React App is SO close to having everything we need for this application.
+The main challenge is that it is very hardcoded in how it generates the production build files.
+Everything else works great for Bugomattic and keeps things really clean and simple.
+
+For deploying internally at a8c, we just need one directory of all the css and js files.
+We also need those files to have the same static name overtime for easy deployment.
+(We handle cache busting in our own way.)
+
+Create React App includes content hashes in their build names, and outputs a more nested directory structure.
+
+So, for now, to keep the many benefits of using Create React App (namely simplicity), we'll just massage
+the output files into the structure we need with this script.
+
+In the future if we do end up needing to ditch Create React App, we can probably scrap this script in favor
+of webpack configuration.
+*/
+
+const originalOutputDirectory = path.resolve( __dirname, '..', 'build' );
 const targetOutputDirectory = path.resolve( __dirname, '..', 'dist' );
 
-if ( ! fs.existsSync( createReactAppOutputDirectory ) ) {
+console.log(
+	'Transforming the Create React App build output into deployment-ready directory for A8c...'
+);
+console.log( `Build files will be located at: ${ targetOutputDirectory }` );
+
+if ( ! fs.existsSync( originalOutputDirectory ) ) {
 	console.error(
 		'Unable to find the build directory from Create React App. Did you run "react-scripts build" first?'
 	);
 	process.exit( 1 );
 }
 
+// Create a fresh output directory
 if ( fs.existsSync( targetOutputDirectory ) ) {
 	fs.rmSync( targetOutputDirectory, { recursive: true } );
 }
 fs.mkdirSync( targetOutputDirectory, { recursive: true } );
 
-const cssDirectory = path.join( createReactAppOutputDirectory, 'static', 'css' );
-const jsDirectory = path.join( createReactAppOutputDirectory, 'static', 'js' );
+const originalCssDirectory = path.join( originalOutputDirectory, 'static', 'css' );
+const originalJsDirectory = path.join( originalOutputDirectory, 'static', 'js' );
 
-const allCssFiles = fs.readdirSync( cssDirectory );
-const coreCssFilename = allCssFiles.find( ( filname ) => filname.endsWith( '.css' ) );
-const cssMapFilename = allCssFiles.find( ( filname ) => filname.endsWith( '.map' ) );
-
-const allJsFiles = fs.readdirSync( jsDirectory );
-const coreJsFilename = allJsFiles.find( ( filname ) => filname.endsWith( '.js' ) );
-const jsMapFilename = allJsFiles.find( ( filname ) => filname.endsWith( '.map' ) );
-
-const targetOutputCssFilename = 'bugomattic.bundle.css';
-const targetOutputCssMapFilename = 'bugomattic.bundle.css.map';
-const targetOutputJsFilename = 'bugomattic.bundle.js';
-const targetOutputJsMapFilename = 'bugomattic.bundle.js.map';
-
-fs.renameSync(
-	path.join( cssDirectory, coreCssFilename ),
-	path.join( targetOutputDirectory, targetOutputCssFilename )
+const allOriginalCssFiles = fs.readdirSync( originalCssDirectory );
+const originalCssFilename = allOriginalCssFiles.find( ( filename ) => filename.endsWith( '.css' ) );
+const originalCssMapFilename = allOriginalCssFiles.find( ( filename ) =>
+	filename.endsWith( '.map' )
 );
 
-fs.renameSync(
-	path.join( cssDirectory, cssMapFilename ),
-	path.join( targetOutputDirectory, targetOutputCssMapFilename )
+if ( originalCssFilename === undefined || originalCssMapFilename === undefined ) {
+	console.error(
+		`Unable to find expected css build files. Searched in directory: ${ originalCssDirectory }`
+	);
+	process.exit( 1 );
+}
+
+const allOriginalJsFiles = fs.readdirSync( originalJsDirectory );
+const originalJsFilename = allOriginalJsFiles.find( ( filename ) => filename.endsWith( '.js' ) );
+const originalJsMapFilename = allOriginalJsFiles.find( ( filename ) =>
+	filename.endsWith( '.map' )
 );
 
-fs.renameSync(
-	path.join( jsDirectory, coreJsFilename ),
-	path.join( targetOutputDirectory, targetOutputJsFilename )
-);
+if ( originalJsFilename === undefined || originalJsMapFilename === undefined ) {
+	console.error(
+		`Unable to find expected js build files. Searched in directory: ${ originalJsDirectory }`
+	);
+	process.exit( 1 );
+}
 
-fs.renameSync(
-	path.join( jsDirectory, jsMapFilename ),
-	path.join( targetOutputDirectory, targetOutputJsMapFilename )
-);
+const targetCssFilename = 'bugomattic.bundle.css';
+const targetCssMapFilename = 'bugomattic.bundle.css.map';
+const targetJsFilename = 'bugomattic.bundle.js';
+const targetJsMapFilename = 'bugomattic.bundle.js.map';
 
-const cssContents = fs.readFileSync( path.join( targetOutputDirectory, targetOutputCssFilename ), {
+// We use these paths a lot later, so let's define them once now.
+const targetCssPath = path.join( targetOutputDirectory, targetCssFilename );
+const targetJsPath = path.join( targetOutputDirectory, targetJsFilename );
+
+// Move and rename all the build files.
+try {
+	fs.renameSync( path.join( originalCssDirectory, originalCssFilename ), targetCssPath );
+
+	fs.renameSync(
+		path.join( originalCssDirectory, originalCssMapFilename ),
+		path.join( targetOutputDirectory, targetCssMapFilename )
+	);
+
+	fs.renameSync( path.join( originalJsDirectory, originalJsFilename ), targetJsPath );
+
+	fs.renameSync(
+		path.join( originalJsDirectory, originalJsMapFilename ),
+		path.join( targetOutputDirectory, targetJsMapFilename )
+	);
+} catch ( error ) {
+	console.error(
+		`Error occurred when trying to move and rename the build files. Original error: ${ error.toString() }`
+	);
+	process.exit( 1 );
+}
+
+// Swap out the map file reference in the CSS file
+const cssContents = fs.readFileSync( targetCssPath, {
 	encoding: 'utf-8',
 } );
-const regexSafeCssMapName = cssMapFilename.replace( /\./g, '\\.' );
+// Since we are using the Regex constructor with a string, we need to escape some symbols.
+const regexSafeCssMapName = originalCssMapFilename.replace( /\./g, '\\.' );
+// Including the 'sourceMappingUrl' gives us a bit more accuracy in making the swap.
 const cssRegex = new RegExp( `sourceMappingURL=${ regexSafeCssMapName }`, 'm' );
-const modifiedCss = cssContents.replace(
-	cssRegex,
-	`sourceMappingURL=${ targetOutputCssMapFilename }`
-);
+const modifiedCss = cssContents.replace( cssRegex, `sourceMappingURL=${ targetCssMapFilename }` );
+// We can easily check if we were actually successful!
 if ( ! modifiedCss.endsWith( '/*# sourceMappingURL=bugomattic.bundle.css.map*/' ) ) {
-	console.error( 'Unable to correctly replace the CSS map reference.' );
+	console.error( 'Unable to correctly replace the css map reference.' );
 	process.exit( 1 );
 }
-fs.writeFileSync( path.join( targetOutputDirectory, targetOutputCssFilename ), modifiedCss );
+fs.writeFileSync( targetCssPath, modifiedCss );
 
-const jsContents = fs.readFileSync( path.join( targetOutputDirectory, targetOutputJsFilename ), {
+// Swap out the map file reference in the JS file.
+const jsContents = fs.readFileSync( targetJsPath, {
 	encoding: 'utf-8',
 } );
-const regexSafeJsMapName = jsMapFilename.replace( /\./g, '\\.' );
+const regexSafeJsMapName = originalJsMapFilename.replace( /\./g, '\\.' );
 const jsRegex = new RegExp( `sourceMappingURL=${ regexSafeJsMapName }`, 'm' );
-const modifiedJs = jsContents.replace( jsRegex, `sourceMappingURL=${ targetOutputJsMapFilename }` );
+const modifiedJs = jsContents.replace( jsRegex, `sourceMappingURL=${ targetJsMapFilename }` );
 if ( ! modifiedJs.endsWith( '//# sourceMappingURL=bugomattic.bundle.js.map' ) ) {
-	console.error( 'Unable to correctly replace the JS map reference.' );
+	console.error( 'Unable to correctly replace the js map reference.' );
 	process.exit( 1 );
 }
-fs.writeFileSync( path.join( targetOutputDirectory, targetOutputJsFilename ), modifiedJs );
+fs.writeFileSync( targetJsPath, modifiedJs );
 
-fs.rmSync( createReactAppOutputDirectory, { recursive: true } );
+// Finally, clean up the original build directory.
+fs.rmSync( originalOutputDirectory, { recursive: true } );

--- a/bin/prepare-a8c-deploy.js
+++ b/bin/prepare-a8c-deploy.js
@@ -14,7 +14,7 @@ We also need those files to have the same static name overtime for easy deployme
 Create React App includes content hashes in their build names, and outputs a more nested directory structure.
 
 So, for now, to keep the many benefits of using Create React App (namely simplicity), we'll just massage
-the output files into the structure we need with this script.
+the output files into the structure we need with this script. The tradeoff makes sense for now.
 
 In the future if we do end up needing to ditch Create React App, we can probably scrap this script in favor
 of webpack configuration.

--- a/bin/prepare-a8c-deploy.js
+++ b/bin/prepare-a8c-deploy.js
@@ -62,6 +62,10 @@ const modifiedCss = cssContents.replace(
 	cssRegex,
 	`sourceMappingURL=${ targetOutputCssMapFilename }`
 );
+if ( ! modifiedCss.endsWith( '/*# sourceMappingURL=bugomattic.bundle.css.map*/' ) ) {
+	console.error( 'Unable to correctly replace the CSS map reference.' );
+	process.exit( 1 );
+}
 fs.writeFileSync( path.join( targetOutputDirectory, targetOutputCssFilename ), modifiedCss );
 
 const jsContents = fs.readFileSync( path.join( targetOutputDirectory, targetOutputJsFilename ), {
@@ -70,6 +74,10 @@ const jsContents = fs.readFileSync( path.join( targetOutputDirectory, targetOutp
 const regexSafeJsMapName = jsMapFilename.replace( /\./g, '\\.' );
 const jsRegex = new RegExp( `sourceMappingURL=${ regexSafeJsMapName }`, 'm' );
 const modifiedJs = jsContents.replace( jsRegex, `sourceMappingURL=${ targetOutputJsMapFilename }` );
+if ( ! modifiedJs.endsWith( '//# sourceMappingURL=bugomattic.bundle.js.map' ) ) {
+	console.error( 'Unable to correctly replace the JS map reference.' );
+	process.exit( 1 );
+}
 fs.writeFileSync( path.join( targetOutputDirectory, targetOutputJsFilename ), modifiedJs );
 
 fs.rmSync( createReactAppOutputDirectory, { recursive: true } );

--- a/bin/prepare-a8c-deploy.js
+++ b/bin/prepare-a8c-deploy.js
@@ -1,0 +1,75 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const createReactAppOutputDirectory = path.resolve( __dirname, '..', 'build' );
+const targetOutputDirectory = path.resolve( __dirname, '..', 'dist' );
+
+if ( ! fs.existsSync( createReactAppOutputDirectory ) ) {
+	console.error(
+		'Unable to find the build directory from Create React App. Did you run "react-scripts build" first?'
+	);
+	process.exit( 1 );
+}
+
+if ( fs.existsSync( targetOutputDirectory ) ) {
+	fs.rmSync( targetOutputDirectory, { recursive: true } );
+}
+fs.mkdirSync( targetOutputDirectory, { recursive: true } );
+
+const cssDirectory = path.join( createReactAppOutputDirectory, 'static', 'css' );
+const jsDirectory = path.join( createReactAppOutputDirectory, 'static', 'js' );
+
+const allCssFiles = fs.readdirSync( cssDirectory );
+const coreCssFilename = allCssFiles.find( ( filname ) => filname.endsWith( '.css' ) );
+const cssMapFilename = allCssFiles.find( ( filname ) => filname.endsWith( '.map' ) );
+
+const allJsFiles = fs.readdirSync( jsDirectory );
+const coreJsFilename = allJsFiles.find( ( filname ) => filname.endsWith( '.js' ) );
+const jsMapFilename = allJsFiles.find( ( filname ) => filname.endsWith( '.map' ) );
+
+const targetOutputCssFilename = 'bugomattic.bundle.css';
+const targetOutputCssMapFilename = 'bugomattic.bundle.css.map';
+const targetOutputJsFilename = 'bugomattic.bundle.js';
+const targetOutputJsMapFilename = 'bugomattic.bundle.js.map';
+
+fs.renameSync(
+	path.join( cssDirectory, coreCssFilename ),
+	path.join( targetOutputDirectory, targetOutputCssFilename )
+);
+
+fs.renameSync(
+	path.join( cssDirectory, cssMapFilename ),
+	path.join( targetOutputDirectory, targetOutputCssMapFilename )
+);
+
+fs.renameSync(
+	path.join( jsDirectory, coreJsFilename ),
+	path.join( targetOutputDirectory, targetOutputJsFilename )
+);
+
+fs.renameSync(
+	path.join( jsDirectory, jsMapFilename ),
+	path.join( targetOutputDirectory, targetOutputJsMapFilename )
+);
+
+const cssContents = fs.readFileSync( path.join( targetOutputDirectory, targetOutputCssFilename ), {
+	encoding: 'utf-8',
+} );
+const regexSafeCssMapName = cssMapFilename.replace( /\./g, '\\.' );
+const cssRegex = new RegExp( `sourceMappingURL=${ regexSafeCssMapName }`, 'm' );
+const modifiedCss = cssContents.replace(
+	cssRegex,
+	`sourceMappingURL=${ targetOutputCssMapFilename }`
+);
+fs.writeFileSync( path.join( targetOutputDirectory, targetOutputCssFilename ), modifiedCss );
+
+const jsContents = fs.readFileSync( path.join( targetOutputDirectory, targetOutputJsFilename ), {
+	encoding: 'utf-8',
+} );
+const regexSafeJsMapName = jsMapFilename.replace( /\./g, '\\.' );
+const jsRegex = new RegExp( `sourceMappingURL=${ regexSafeJsMapName }`, 'm' );
+const modifiedJs = jsContents.replace( jsRegex, `sourceMappingURL=${ targetOutputJsMapFilename }` );
+fs.writeFileSync( path.join( targetOutputDirectory, targetOutputJsFilename ), modifiedJs );
+
+fs.rmSync( createReactAppOutputDirectory, { recursive: true } );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	},
 	"scripts": {
 		"start": "react-scripts start",
-		"build": "react-scripts build",
+		"build": "react-scripts build && node bin/prepare-a8c-deploy.js",
 		"test": "react-scripts test",
 		"test:once": "react-scripts test --watchAll=false",
 		"eject": "react-scripts eject",

--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -6,6 +6,26 @@ import { ApiClient } from './types';
  */
 export const productionApiClient: ApiClient = {
 	loadReportingConfig: async () => {
-		throw new Error( 'Not implemented!' );
+		const nonce = globalThis.nonce;
+		const nonceHeaderName = globalThis.nonceHeaderName;
+
+		const request = new Request( '/wp-json/bugomattic/v1/reporting-config/', {
+			method: 'GET',
+			credentials: 'same-origin',
+			headers: new Headers( {
+				[ nonceHeaderName ]: nonce,
+			} ),
+		} );
+		const response = await fetch( request );
+
+		if ( response.ok ) {
+			return response.json();
+		} else {
+			throw new Error(
+				`Load Reporting Config web request failed with status code ${
+					response.status
+				}. Response body: ${ await response.json() }`
+			);
+		}
 	},
 };

--- a/src/api/window.d.ts
+++ b/src/api/window.d.ts
@@ -1,0 +1,5 @@
+/* eslint-disable no-var */
+export declare global {
+	var nonce: string;
+	var nonceHeaderName: string;
+}

--- a/src/app/app.module.css
+++ b/src/app/app.module.css
@@ -1,12 +1,15 @@
 .appHeader {
-	background-color: #282c34;
 	min-height: 4rem;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
+	border-bottom: 2px solid gray;
+	margin-bottom: 3rem;
+}
+
+.appHeader h1 {
 	font-size: 2rem;
-	color: white;
 }
 
 .content {

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { DebugView } from '../debug/debug-view';
 import { FakeFlow } from '../debug/fake-flow';
 import {
@@ -28,12 +28,17 @@ export function App() {
 		}
 	}, [ reportingConfigLoadStatus, dispatch ] );
 
+	const reloadConfig = useCallback( () => {
+		dispatch( loadReportingConfig() );
+	}, [ dispatch ] );
+
 	return (
 		<div className={ styles.app }>
 			<header className={ styles.appHeader }>
 				<h1>Bugomattic (Ragnarok)</h1>
 			</header>
 			<main className={ styles.content }>
+				<button onClick={ reloadConfig }>Reload Reporting Config</button>
 				{ reportingConfigLoadStatus === 'loading' && <p>Reporting config is loading...</p> }
 				<FakeFlow></FakeFlow>
 				<DebugView data={ debugData } header="Reporting Config"></DebugView>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,11 +3,11 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import { App, setupStore } from './app';
 import { Provider } from 'react-redux';
-import { localApiClient } from './api';
+import { localApiClient, productionApiClient } from './api';
 import { localMonitoringClient, MonitoringProvider } from './monitoring';
 
 const root = ReactDOM.createRoot( document.getElementById( 'root' ) as HTMLElement );
-const store = setupStore( localApiClient );
+const store = setupStore( productionApiClient );
 root.render(
 	<React.StrictMode>
 		<MonitoringProvider monitoringClient={ localMonitoringClient }>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,19 +4,30 @@ import './index.css';
 import { App, setupStore } from './app';
 import { Provider } from 'react-redux';
 import { localApiClient, productionApiClient } from './api';
-import { localMonitoringClient, MonitoringProvider } from './monitoring';
+import {
+	localMonitoringClient,
+	MonitoringProvider,
+	productionMonitoringClient,
+} from './monitoring';
+
+const monitoringClient = isProduction() ? productionMonitoringClient : localMonitoringClient;
+const apiClient = isProduction() ? productionApiClient : localApiClient;
+const store = setupStore( apiClient );
 
 const root = ReactDOM.createRoot( document.getElementById( 'root' ) as HTMLElement );
-const store = setupStore( productionApiClient );
 root.render(
 	<React.StrictMode>
-		<MonitoringProvider monitoringClient={ localMonitoringClient }>
+		<MonitoringProvider monitoringClient={ monitoringClient }>
 			<Provider store={ store }>
 				<App />
 			</Provider>
 		</MonitoringProvider>
 	</React.StrictMode>
 );
+
+function isProduction() {
+	return process.env.NODE_ENV === 'production';
+}
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,13 +4,10 @@ import './index.css';
 import { App, setupStore } from './app';
 import { Provider } from 'react-redux';
 import { localApiClient, productionApiClient } from './api';
-import {
-	localMonitoringClient,
-	MonitoringProvider,
-	productionMonitoringClient,
-} from './monitoring';
+import { localMonitoringClient, MonitoringProvider } from './monitoring';
 
-const monitoringClient = isProduction() ? productionMonitoringClient : localMonitoringClient;
+// TODO: use a production monitoring client when it's actually implemented fully.
+const monitoringClient = isProduction() ? localMonitoringClient : localMonitoringClient;
 const apiClient = isProduction() ? productionApiClient : localApiClient;
 const store = setupStore( apiClient );
 

--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './local-monitoring-client';
 export * from './monitoring-provider';
+export * from './production-monitoring-client';

--- a/src/monitoring/production-monitoring-client.ts
+++ b/src/monitoring/production-monitoring-client.ts
@@ -1,0 +1,24 @@
+import { AnalyticsClient, LoggerClient, MonitoringClient } from './types';
+
+const productionLogger: LoggerClient = {
+	debug: ( message, additionalDetails? ) => {
+		throw new Error( 'Not implemented' );
+	},
+	info: ( message, additionalDetails? ) => {
+		throw new Error( 'Not implemented' );
+	},
+	error: ( message, additionalDetails? ) => {
+		throw new Error( 'Not implemented' );
+	},
+};
+
+const productionAnalytics: AnalyticsClient = {
+	recordEvent: ( eventName, properties? ) => {
+		throw new Error( 'Not implemented' );
+	},
+};
+
+export const productionMonitoringClient: MonitoringClient = {
+	logger: productionLogger,
+	analytics: productionAnalytics,
+};


### PR DESCRIPTION
#### What Does This PR Add/Change?

In short, this sets up the initial integration and build pipeline for production deployment in MC at A8c. The big changes include...
- An initial production implementation of the `ApiClient` that loads the reporting config from the MC REST API
- Dependency injection in the main `index.tsx` based on local or prod running.
- A build script** that takes the output of Create React App and prepares it for A8c MC deployment.

** Note: I've opted to modify the build files than just ditch Create React App for now. We get so much simplicity from those scripts, and apart from the build output, it works great for us. See the comment in the `bin` script for more details.

There are a bunch of small, mostly meaningless tweaks elsewhere!

#### Testing Instructions

I've already tested these files in MC and they work great! 👍 

You can test the production build locally: `yarn build`.
You should see a single `dist` folder with...
- a css file
- a css map file
- a js file
- a js map file

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #