### PR TITLE
Move reducer creation into function

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -10,15 +10,17 @@ import { ApiClient } from '../api';
 import { issueDetailsReducer } from '../issue-details';
 import { reportingConfigReducer } from '../reporting-config';
 
-const rootReducer = combineReducers( {
-	reportingConfig: reportingConfigReducer,
-	issueDetails: issueDetailsReducer,
-	completedTasks: completedTasksReducer,
-} );
+function createRootReducer() {
+	return combineReducers( {
+		reportingConfig: reportingConfigReducer,
+		issueDetails: issueDetailsReducer,
+		completedTasks: completedTasksReducer,
+	} );
+}
 
 export function setupStore( apiClient: ApiClient, preloadedState?: PreloadedState< RootState > ) {
 	return configureStore( {
-		reducer: rootReducer,
+		reducer: createRootReducer(),
 		// This is where the app dependency injection of the ApiClient happens.
 		// We are providing an instance of the ApiClient to all thunks created
 		// with createAsyncThunk().
@@ -34,7 +36,7 @@ export function setupStore( apiClient: ApiClient, preloadedState?: PreloadedStat
 }
 
 // These provide richer TypeScript typings for these core parts of the Redux store.
-export type RootState = ReturnType< typeof rootReducer >;
+export type RootState = ReturnType< ReturnType< typeof createRootReducer > >;
 export type AppStore = ReturnType< typeof setupStore >;
 export type AppDispatch = AppStore[ 'dispatch' ];
 export type AppThunk< ReturnType = void > = ThunkAction<


### PR DESCRIPTION
#### What Does This PR Add/Change?

In short, fixes a problem with how module importing and resolution was working for the `app` directory.

We were mixing two things which was a bad combo...

- `index.ts` style indexing in all our subdirectories
- "Unwrapped" code -- code statements defined at the top level (not wrapped in functions or class definitions), which executes as soon as the module is first loaded.

This means if anyone imported anything from the `app` index, they were running core redux code at import time. This lead to some weird race conditions where redux thought it was getting undefined reducers. This didn't cause production bugs, just console errors, but still pointed to a troubling cocktail.

We're going to keep using the index convention for now, which means that all code in indexed directories should be thoughtfully wrapped (unless it's just exporting constant static values, e.g.)

#### Testing Instructions

- [x] App should still run (`yarn start`)
- [x] Unit tests shouldn't log console errors

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #10 