### PR TITLE
Switch Blocker type to Urgent -- Round 1

### DIFF
--- a/public/local-reporting-configs/default.json
+++ b/public/local-reporting-configs/default.json
@@ -35,9 +35,9 @@
 					}
 				}
 			],
-			"blocker": [
+			"urgent": [
 				{
-					"details": "Product | Blocker | Slack link",
+					"details": "Product | Urgent | Slack link",
 					"link": {
 						"type": "slack",
 						"channel": "product"
@@ -78,7 +78,7 @@
 							}
 						}
 					],
-					"blocker": [
+					"urgent": [
 						{
 							"details": "Duplicate Task | P2 link",
 							"link": {
@@ -130,9 +130,9 @@
 									}
 								}
 							],
-							"blocker": [
+							"urgent": [
 								{
-									"details": "Feature (Under Feature Group) | Blocker | GitHub link",
+									"details": "Feature (Under Feature Group) | Urgent | GitHub link",
 									"link": {
 										"type": "github",
 										"repository": "Automattic/fake-repo",
@@ -191,9 +191,9 @@
 									"details": "Alternative Feature | Feature Request | details only"
 								}
 							],
-							"blocker": [
+							"urgent": [
 								{
-									"details": "Alternative Feature | Blocker | details only"
+									"details": "Alternative Feature | Urgent | details only"
 								}
 							]
 						}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -52,5 +52,5 @@ export interface ApiFeature {
 export interface ApiTasks {
 	bug: TaskDetails[];
 	featureRequest: TaskDetails[];
-	blocker: TaskDetails[];
+	urgent: TaskDetails[];
 }

--- a/src/combined-selectors/__tests__/relevant-task-ids.test.ts
+++ b/src/combined-selectors/__tests__/relevant-task-ids.test.ts
@@ -34,7 +34,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [ 'feature_task' ],
 						featureRequest: [],
-						blocker: [],
+						urgent: [],
 					},
 				},
 			},
@@ -88,7 +88,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [ 'feature_task' ],
 						featureRequest: [],
-						blocker: [],
+						urgent: [],
 					},
 				},
 			},
@@ -155,7 +155,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [ productTaskId ],
 						featureRequest: [],
-						blocker: [],
+						urgent: [],
 					},
 					featureGroupIds: [ 'feature_group_id' ],
 					featureIds: [ featureId ],
@@ -169,7 +169,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [ featureGroupTaskId ],
 						featureRequest: [],
-						blocker: [],
+						urgent: [],
 					},
 					featureIds: [ featureId ],
 				},
@@ -183,7 +183,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [ firstFeatureTaskId, secondFeatureTaskId ],
 						featureRequest: [],
-						blocker: [],
+						urgent: [],
 					},
 				},
 			},
@@ -255,7 +255,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [],
 						featureRequest: [ 'product_task' ],
-						blocker: [],
+						urgent: [],
 					},
 					featureGroupIds: [ 'feature_group_id' ],
 					featureIds: [ featureId ],
@@ -269,7 +269,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [],
 						featureRequest: [ 'feature_group_task' ],
-						blocker: [],
+						urgent: [],
 					},
 					featureIds: [ featureId ],
 				},
@@ -283,7 +283,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [],
 						featureRequest: [ featureTaskId ],
-						blocker: [],
+						urgent: [],
 					},
 				},
 			},
@@ -346,7 +346,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [],
 						featureRequest: [],
-						blocker: [ 'product_task' ],
+						urgent: [ 'product_task' ],
 					},
 					featureGroupIds: [],
 					featureIds: [ featureId ],
@@ -362,7 +362,7 @@ describe( '[selectRelevantTaskIds]', () => {
 					taskMapping: {
 						bug: [],
 						featureRequest: [],
-						blocker: [ featureTaskId ],
+						urgent: [ featureTaskId ],
 					},
 				},
 			},
@@ -378,7 +378,7 @@ describe( '[selectRelevantTaskIds]', () => {
 				error: null,
 			},
 			issueDetails: {
-				issueType: 'blocker',
+				issueType: 'urgent',
 				featureId: featureId,
 				issueTitle: '',
 			},

--- a/src/common/svgs/info.svg
+++ b/src/common/svgs/info.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_0_1074" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="2" y="2" width="20" height="20">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M22 12C22 6.477 17.523 2 12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22C17.523 22 22 17.523 22 12ZM12 4C7.589 4 4 7.589 4 12C4 16.411 7.589 20 12 20C16.411 20 20 16.411 20 12C20 7.589 16.411 4 12 4ZM13 9V7H11V9H13ZM13 11V17H11V11H13Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_0_1074)">
+<rect width="24" height="24" fill="#2c3338"/>
+</g>
+</svg>

--- a/src/issue-details/types.ts
+++ b/src/issue-details/types.ts
@@ -1,4 +1,4 @@
-export type IssueType = 'unset' | 'bug' | 'featureRequest' | 'blocker';
+export type IssueType = 'unset' | 'bug' | 'featureRequest' | 'urgent';
 export type FeatureId = string | null;
 export interface IssueDetails {
 	featureId: FeatureId;

--- a/src/reporting-config/__tests__/__snapshots__/reporting-config-parsers.test.ts.snap
+++ b/src/reporting-config/__tests__/__snapshots__/reporting-config-parsers.test.ts.snap
@@ -18,14 +18,14 @@ Object {
       "name": "FakeFeatureGroup",
       "productId": "FakeProduct",
       "taskMapping": Object {
-        "blocker": Array [
-          "FakeProduct__FakeFeatureGroup__blocker__0",
-        ],
         "bug": Array [
           "FakeProduct__FakeFeatureGroup__bug__0",
         ],
         "featureRequest": Array [
           "FakeProduct__FakeFeatureGroup__featureRequest__0",
+        ],
+        "urgent": Array [
+          "FakeProduct__FakeFeatureGroup__urgent__0",
         ],
       },
     },
@@ -47,10 +47,6 @@ Object {
       "parentId": "FakeProduct__FakeFeatureGroup",
       "parentType": "featureGroup",
       "taskMapping": Object {
-        "blocker": Array [
-          "FakeProduct__FakeFeatureGroup__GroupNestedFeature__blocker__0",
-          "FakeProduct__FakeFeatureGroup__GroupNestedFeature__blocker__1",
-        ],
         "bug": Array [
           "FakeProduct__FakeFeatureGroup__GroupNestedFeature__bug__0",
           "FakeProduct__FakeFeatureGroup__GroupNestedFeature__bug__1",
@@ -58,6 +54,10 @@ Object {
         "featureRequest": Array [
           "FakeProduct__FakeFeatureGroup__GroupNestedFeature__featureRequest__0",
           "FakeProduct__FakeFeatureGroup__GroupNestedFeature__featureRequest__1",
+        ],
+        "urgent": Array [
+          "FakeProduct__FakeFeatureGroup__GroupNestedFeature__urgent__0",
+          "FakeProduct__FakeFeatureGroup__GroupNestedFeature__urgent__1",
         ],
       },
     },
@@ -77,14 +77,14 @@ Object {
       "parentId": "FakeProduct",
       "parentType": "product",
       "taskMapping": Object {
-        "blocker": Array [
-          "FakeProduct__ProductNestedFeature__blocker__0",
-        ],
         "bug": Array [
           "FakeProduct__ProductNestedFeature__bug__0",
         ],
         "featureRequest": Array [
           "FakeProduct__ProductNestedFeature__featureRequest__0",
+        ],
+        "urgent": Array [
+          "FakeProduct__ProductNestedFeature__urgent__0",
         ],
       },
     },
@@ -107,31 +107,19 @@ Object {
       ],
       "name": "FakeProduct",
       "taskMapping": Object {
-        "blocker": Array [
-          "FakeProduct__blocker__0",
-        ],
         "bug": Array [
           "FakeProduct__bug__0",
         ],
         "featureRequest": Array [
           "FakeProduct__featureRequest__0",
         ],
+        "urgent": Array [
+          "FakeProduct__urgent__0",
+        ],
       },
     },
   },
   "tasks": Object {
-    "FakeProduct__FakeFeatureGroup__GroupNestedFeature__blocker__0": Object {
-      "id": "FakeProduct__FakeFeatureGroup__GroupNestedFeature__blocker__0",
-      "parentId": "FakeProduct__FakeFeatureGroup__GroupNestedFeature",
-      "parentType": "feature",
-      "title": "Feature nested under group | blocker | index 0",
-    },
-    "FakeProduct__FakeFeatureGroup__GroupNestedFeature__blocker__1": Object {
-      "id": "FakeProduct__FakeFeatureGroup__GroupNestedFeature__blocker__1",
-      "parentId": "FakeProduct__FakeFeatureGroup__GroupNestedFeature",
-      "parentType": "feature",
-      "title": "Feature nested under group | blocker | index 1",
-    },
     "FakeProduct__FakeFeatureGroup__GroupNestedFeature__bug__0": Object {
       "id": "FakeProduct__FakeFeatureGroup__GroupNestedFeature__bug__0",
       "parentId": "FakeProduct__FakeFeatureGroup__GroupNestedFeature",
@@ -156,11 +144,17 @@ Object {
       "parentType": "feature",
       "title": "Feature nested under group | feature request | index 1",
     },
-    "FakeProduct__FakeFeatureGroup__blocker__0": Object {
-      "id": "FakeProduct__FakeFeatureGroup__blocker__0",
-      "parentId": "FakeProduct__FakeFeatureGroup",
-      "parentType": "featureGroup",
-      "title": "Feature group | blocker",
+    "FakeProduct__FakeFeatureGroup__GroupNestedFeature__urgent__0": Object {
+      "id": "FakeProduct__FakeFeatureGroup__GroupNestedFeature__urgent__0",
+      "parentId": "FakeProduct__FakeFeatureGroup__GroupNestedFeature",
+      "parentType": "feature",
+      "title": "Feature nested under group | urgent | index 0",
+    },
+    "FakeProduct__FakeFeatureGroup__GroupNestedFeature__urgent__1": Object {
+      "id": "FakeProduct__FakeFeatureGroup__GroupNestedFeature__urgent__1",
+      "parentId": "FakeProduct__FakeFeatureGroup__GroupNestedFeature",
+      "parentType": "feature",
+      "title": "Feature nested under group | urgent | index 1",
     },
     "FakeProduct__FakeFeatureGroup__bug__0": Object {
       "id": "FakeProduct__FakeFeatureGroup__bug__0",
@@ -174,11 +168,11 @@ Object {
       "parentType": "featureGroup",
       "title": "Feature group | feature request",
     },
-    "FakeProduct__ProductNestedFeature__blocker__0": Object {
-      "id": "FakeProduct__ProductNestedFeature__blocker__0",
-      "parentId": "FakeProduct__ProductNestedFeature",
-      "parentType": "feature",
-      "title": "Feature nested under product blocker task",
+    "FakeProduct__FakeFeatureGroup__urgent__0": Object {
+      "id": "FakeProduct__FakeFeatureGroup__urgent__0",
+      "parentId": "FakeProduct__FakeFeatureGroup",
+      "parentType": "featureGroup",
+      "title": "Feature group | urgent",
     },
     "FakeProduct__ProductNestedFeature__bug__0": Object {
       "id": "FakeProduct__ProductNestedFeature__bug__0",
@@ -192,11 +186,11 @@ Object {
       "parentType": "feature",
       "title": "Feature nested under product feature-request task",
     },
-    "FakeProduct__blocker__0": Object {
-      "id": "FakeProduct__blocker__0",
-      "parentId": "FakeProduct",
-      "parentType": "product",
-      "title": "Product | blocker",
+    "FakeProduct__ProductNestedFeature__urgent__0": Object {
+      "id": "FakeProduct__ProductNestedFeature__urgent__0",
+      "parentId": "FakeProduct__ProductNestedFeature",
+      "parentType": "feature",
+      "title": "Feature nested under product urgent task",
     },
     "FakeProduct__bug__0": Object {
       "id": "FakeProduct__bug__0",
@@ -209,6 +203,12 @@ Object {
       "parentId": "FakeProduct",
       "parentType": "product",
       "title": "Product | feature-request",
+    },
+    "FakeProduct__urgent__0": Object {
+      "id": "FakeProduct__urgent__0",
+      "parentId": "FakeProduct",
+      "parentType": "product",
+      "title": "Product | urgent",
     },
   },
 }

--- a/src/reporting-config/__tests__/reporting-config-parsers.test.ts
+++ b/src/reporting-config/__tests__/reporting-config-parsers.test.ts
@@ -14,7 +14,7 @@ function createFakeReportingConfigResponse(): ReportingConfigApiResponse {
 			tasks: {
 				bug: [ { title: 'Product | bug' } ],
 				featureRequest: [ { title: 'Product | feature-request' } ],
-				blocker: [ { title: 'Product | blocker' } ],
+				urgent: [ { title: 'Product | urgent' } ],
 			},
 			featureGroups: {
 				FakeFeatureGroup: {
@@ -28,7 +28,7 @@ function createFakeReportingConfigResponse(): ReportingConfigApiResponse {
 					tasks: {
 						bug: [ { title: 'Feature group | bug' } ],
 						featureRequest: [ { title: 'Feature group | feature request' } ],
-						blocker: [ { title: 'Feature group | blocker' } ],
+						urgent: [ { title: 'Feature group | urgent' } ],
 					},
 					features: {
 						GroupNestedFeature: {
@@ -49,9 +49,9 @@ function createFakeReportingConfigResponse(): ReportingConfigApiResponse {
 									{ title: 'Feature nested under group | feature request | index 0' },
 									{ title: 'Feature nested under group | feature request | index 1' },
 								],
-								blocker: [
-									{ title: 'Feature nested under group | blocker | index 0' },
-									{ title: 'Feature nested under group | blocker | index 1' },
+								urgent: [
+									{ title: 'Feature nested under group | urgent | index 0' },
+									{ title: 'Feature nested under group | urgent | index 1' },
 								],
 							},
 						},
@@ -71,7 +71,7 @@ function createFakeReportingConfigResponse(): ReportingConfigApiResponse {
 					tasks: {
 						bug: [ { title: 'Feature nested under product bug task' } ],
 						featureRequest: [ { title: 'Feature nested under product feature-request task' } ],
-						blocker: [ { title: 'Feature nested under product blocker task' } ],
+						urgent: [ { title: 'Feature nested under product urgent task' } ],
 					},
 				},
 			},

--- a/src/reporting-config/reporting-config-parsers.ts
+++ b/src/reporting-config/reporting-config-parsers.ts
@@ -231,12 +231,12 @@ interface NormalizedTaskOutput {
 function normalizeTasks( apiTasks: ApiTasks, context: TaskContext ): NormalizedTaskOutput {
 	const taskMapping: TaskMapping = {
 		bug: [],
-		blocker: [],
+		urgent: [],
 		featureRequest: [],
 	};
 	const normalizedTasks: Tasks = {};
 
-	const issueTypes = [ 'bug', 'featureRequest', 'blocker' ] as const;
+	const issueTypes = [ 'bug', 'featureRequest', 'urgent' ] as const;
 	issueTypes.forEach( ( issueType ) => {
 		apiTasks[ issueType ].forEach( ( taskDetails, index ) => {
 			const taskId = `${ context.parentId }__${ issueType }__${ index }`;

--- a/src/reporting-config/types.ts
+++ b/src/reporting-config/types.ts
@@ -86,7 +86,7 @@ export interface Task extends TaskDetails {
 export interface TaskMapping {
 	bug: string[];
 	featureRequest: string[];
-	blocker: string[];
+	urgent: string[];
 }
 
 export interface SlackLink {

--- a/src/reporting-flow/__tests__/reporting-flow.test.tsx
+++ b/src/reporting-flow/__tests__/reporting-flow.test.tsx
@@ -29,7 +29,7 @@ describe( '[Reporting Flow]', () => {
 		parentType: 'featureGroup',
 		parentId: 'feature_group',
 		taskMapping: {
-			blocker: [],
+			urgent: [],
 			featureRequest: [ 'task_a_featureRequest' ],
 			bug: [ 'task_a_bug' ],
 		},
@@ -41,7 +41,7 @@ describe( '[Reporting Flow]', () => {
 		parentType: 'featureGroup',
 		parentId: 'feature_group',
 		taskMapping: {
-			blocker: [],
+			urgent: [],
 			featureRequest: [],
 			bug: [ 'task_b_bug' ],
 		},

--- a/src/reporting-flow/sub-components/title-and-type-step.tsx
+++ b/src/reporting-flow/sub-components/title-and-type-step.tsx
@@ -67,8 +67,8 @@ function CompletedStep( { title, type }: CompletedStepProps ) {
 
 function getDisplayTextForType( type: IssueType ) {
 	switch ( type ) {
-		case 'blocker':
-			return 'Blocker';
+		case 'urgent':
+			return "It's Urgent!";
 		case 'bug':
 			return 'Bug';
 		case 'featureRequest':

--- a/src/title-type-form/__tests__/title-type-form.test.tsx
+++ b/src/title-type-form/__tests__/title-type-form.test.tsx
@@ -127,8 +127,10 @@ describe( '[TitleTypeForm]', () => {
 				screen.getByRole( 'radio', { name: 'Feature Request', checked: true } )
 			).toBeInTheDocument();
 
-			await user.click( screen.getByRole( 'radio', { name: 'Blocker' } ) );
-			expect( screen.getByRole( 'radio', { name: 'Blocker', checked: true } ) ).toBeInTheDocument();
+			await user.click( screen.getByRole( 'radio', { name: "It's Urgent!" } ) );
+			expect(
+				screen.getByRole( 'radio', { name: "It's Urgent!", checked: true } )
+			).toBeInTheDocument();
 		} );
 
 		test( 'Clicking "Continue" with an unselected issue type causes a form field error to appear', async () => {
@@ -146,7 +148,7 @@ describe( '[TitleTypeForm]', () => {
 
 			expect( screen.getByRole( 'radio', { name: 'Bug' } ) ).toBeInvalid();
 			expect( screen.getByRole( 'radio', { name: 'Feature Request' } ) ).toBeInvalid();
-			expect( screen.getByRole( 'radio', { name: 'Blocker' } ) ).toBeInvalid();
+			expect( screen.getByRole( 'radio', { name: "It's Urgent!" } ) ).toBeInvalid();
 		} );
 
 		test( 'Selecting an issue type causes the form field error to disappear', async () => {
@@ -166,7 +168,7 @@ describe( '[TitleTypeForm]', () => {
 
 			expect( screen.getByRole( 'radio', { name: 'Bug' } ) ).not.toBeInvalid();
 			expect( screen.getByRole( 'radio', { name: 'Feature Request' } ) ).not.toBeInvalid();
-			expect( screen.getByRole( 'radio', { name: 'Blocker' } ) ).not.toBeInvalid();
+			expect( screen.getByRole( 'radio', { name: "It's Urgent!" } ) ).not.toBeInvalid();
 		} );
 	} );
 } );

--- a/src/title-type-form/__tests__/title-type-form.test.tsx
+++ b/src/title-type-form/__tests__/title-type-form.test.tsx
@@ -59,10 +59,10 @@ describe( '[TitleTypeForm]', () => {
 			// Need a custom matcher because the text is split by a span
 			expect(
 				screen.getByText( ( _content, element ) => {
-					if ( ! element?.className.includes( 'limitMessage' ) ) {
+					// The svgs trip up this check for some reason, so need to check for SVG first.
+					if ( element?.nodeName === 'svg' || ! element?.className.includes( 'limitMessage' ) ) {
 						return false;
 					}
-
 					return element.textContent === expectedText;
 				} )
 			).toBeInTheDocument();

--- a/src/title-type-form/title-type-form.module.css
+++ b/src/title-type-form/title-type-form.module.css
@@ -21,6 +21,13 @@
 	margin-bottom: 0.5rem;
 }
 
+.infoIcon {
+	height: 1rem;
+	width: 1rem;
+	margin-left: 0.5rem;
+	cursor: help;
+}
+
 .continueWrapper {
 	display: flex;
 	justify-content: right;

--- a/src/title-type-form/title-type-form.tsx
+++ b/src/title-type-form/title-type-form.tsx
@@ -13,6 +13,7 @@ import {
 	setIssueType,
 } from '../issue-details/issue-details-slice';
 import { IssueType } from '../issue-details/types';
+import { ReactComponent as InfoIcon } from '../common/svgs/info.svg';
 import styles from './title-type-form.module.css';
 
 interface Props {
@@ -64,6 +65,11 @@ export function TitleTypeForm( { onContinue }: Props ) {
 			}
 		}
 	};
+
+	const urgentTooltipId = 'urgent-info-icon';
+	const urgentDescription =
+		'For when you need to escalate something urgently to a product team. ' +
+		'This should usually be reserved for widespread, critical issues such as outages or broken core workflows.';
 
 	let titleErrorMessage: ReactNode = null;
 	if ( showTitleError ) {
@@ -149,9 +155,18 @@ export function TitleTypeForm( { onContinue }: Props ) {
 							onBlur={ handleTypeBlur }
 							aria-required={ true }
 							aria-invalid={ showTypeError }
+							aria-describedby={ urgentTooltipId }
 						/>
 						{ "It's Urgent!" }
+						<InfoIcon
+							aria-hidden={ true }
+							className={ styles.infoIcon }
+							title={ urgentDescription }
+						/>
 					</label>
+					<span className="screenReaderOnly" id={ urgentTooltipId } role="tooltip">
+						{ urgentDescription }
+					</span>
 				</div>
 			</fieldset>
 			<div className={ styles.continueWrapper }>

--- a/src/title-type-form/title-type-form.tsx
+++ b/src/title-type-form/title-type-form.tsx
@@ -142,15 +142,15 @@ export function TitleTypeForm( { onContinue }: Props ) {
 					<label className={ styles.radio }>
 						<input
 							type="radio"
-							checked={ type === 'blocker' }
-							value="blocker"
+							checked={ type === 'urgent' }
+							value="urgent"
 							name="type"
 							onChange={ handleTypeChange }
 							onBlur={ handleTypeBlur }
 							aria-required={ true }
 							aria-invalid={ showTypeError }
 						/>
-						Blocker
+						{ "It's Urgent!" }
 					</label>
 				</div>
 			</fieldset>


### PR DESCRIPTION
#### What Does This PR Add/Change?

This is the first attempt at replacing the "Blocker" type with something better!

For now...
- We use 'urgent' in the data model
- We keep it as a radio
- It's called "It's Urgent!" with a descriptive tooltip icon

#### Testing Instructions

- [x] `yarn test:once` -- still passes
- [x] `yarn start` -- interact with the new radio, check out the new tooltip!

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #