### PR TITLE
Add production monitoring client implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"husky": "^8.0.0",
 		"jest-environment-jsdom": "^27.4.3",
 		"lint-staged": "^13.0.3",
+		"miragejs": "^0.1.47",
 		"prettier": "npm:wp-prettier@latest",
 		"typescript": "^4.8.4"
 	}

--- a/src/api/__tests__/production-api-client.test.ts
+++ b/src/api/__tests__/production-api-client.test.ts
@@ -1,0 +1,134 @@
+import { ProductionApiClient } from '../production-api-client';
+import { createServer, Request, Response } from 'miragejs';
+import { ReportingConfigApiResponse } from '../types';
+import { LogPayload } from '../../monitoring/types';
+
+describe( '[ProductionApiClient]', () => {
+	const fakeNonce = 'abc123';
+	const fakeNonceHeaderName = 'x-fake-nonce';
+
+	const fakeReportingConfig: ReportingConfigApiResponse = {
+		foo: {
+			description: 'bar',
+		},
+	};
+
+	let server: ReturnType< typeof createServer >;
+
+	// Normally we use the "setup" pattern, but we need to teardown the server after each test.
+	// So we're using "beforeEach" and "afterEach" instead.
+	beforeEach( () => {
+		globalThis.nonce = fakeNonce;
+		globalThis.nonceHeaderName = fakeNonceHeaderName;
+
+		server = createServer( {
+			environment: 'test',
+			trackRequests: true,
+			routes() {
+				this.namespace = 'wp-json/bugomattic/v1';
+
+				this.get( '/reporting-config', () => {
+					return fakeReportingConfig;
+				} );
+
+				// We could make a fake DB schema for logs, but that's a bit overkill here.
+				this.post( '/logs', () => {
+					return new Response( 200 );
+				} );
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		server.shutdown();
+	} );
+
+	describe( 'loadReportingConfig()', () => {
+		test( 'Calls the correct endpoint and returns the reporting config', async () => {
+			const apiClient = new ProductionApiClient();
+			const reportingConfig = await apiClient.loadReportingConfig();
+
+			// If this returns correctly, we called the correct endpoint.
+			expect( reportingConfig ).toEqual( fakeReportingConfig );
+		} );
+
+		test( 'The request includes the nonce in the right header', async () => {
+			const apiClient = new ProductionApiClient();
+			await apiClient.loadReportingConfig();
+
+			// The types are borked here, see: https://github.com/pretenderjs/pretender/pull/353
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const lastRequest: Request = ( server.pretender as any ).handledRequests[ 0 ];
+			expect( lastRequest.requestHeaders[ fakeNonceHeaderName ] ).toEqual( fakeNonce );
+		} );
+
+		test( 'Throws an error if the request fails', async () => {
+			const apiClient = new ProductionApiClient();
+
+			const errorBody = {
+				error: 'Something went wrong',
+			};
+
+			server.get( '/reporting-config', () => {
+				return new Response( 500, {}, errorBody );
+			} );
+
+			await expect( apiClient.loadReportingConfig() ).rejects.toThrowError(
+				`Load Reporting Config web request failed with status code 500. Response body: ${ JSON.stringify(
+					errorBody
+				) }`
+			);
+		} );
+	} );
+
+	describe( 'log()', () => {
+		const fakeLogPayload: LogPayload = {
+			feature: 'bugomattic_client',
+			severity: 'info',
+			message: 'This is a test',
+		};
+
+		test( 'Calls the correct endpoint', async () => {
+			const apiClient = new ProductionApiClient();
+			await expect( apiClient.log( fakeLogPayload ) ).resolves.not.toThrowError();
+		} );
+
+		test( 'The request includes the nonce in the right header', async () => {
+			const apiClient = new ProductionApiClient();
+			await apiClient.log( fakeLogPayload );
+
+			// The types are borked here, see: https://github.com/pretenderjs/pretender/pull/353
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const lastRequest: Request = ( server.pretender as any ).handledRequests[ 0 ];
+			expect( lastRequest.requestHeaders[ fakeNonceHeaderName ] ).toEqual( fakeNonce );
+		} );
+
+		test( 'The request includes the log payload in the body', async () => {
+			const apiClient = new ProductionApiClient();
+			await apiClient.log( fakeLogPayload );
+
+			// The types are borked here, see: https://github.com/pretenderjs/pretender/pull/353
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const lastRequest: Request = ( server.pretender as any ).handledRequests[ 0 ];
+			expect( JSON.parse( lastRequest.requestBody ) ).toEqual( fakeLogPayload );
+		} );
+
+		test( 'Throws an error if the request fails', async () => {
+			const apiClient = new ProductionApiClient();
+
+			const errorBody = {
+				error: 'Invalid request',
+			};
+
+			server.post( '/logs', () => {
+				return new Response( 400, {}, errorBody );
+			} );
+
+			await expect( apiClient.log( fakeLogPayload ) ).rejects.toThrowError(
+				`Log web request failed with status code 400. Response body: ${ JSON.stringify(
+					errorBody
+				) }`
+			);
+		} );
+	} );
+} );

--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -26,7 +26,7 @@ export class ProductionApiClient implements ApiClient, LoggerApiClient {
 			throw new Error(
 				`Load Reporting Config web request failed with status code ${
 					response.status
-				}. Response body: ${ await response.json() }`
+				}. Response body: ${ JSON.stringify( await response.json() ) }`
 			);
 		}
 	}
@@ -47,7 +47,7 @@ export class ProductionApiClient implements ApiClient, LoggerApiClient {
 			throw new Error(
 				`Log web request failed with status code ${
 					response.status
-				}. Response body: ${ await response.json() }`
+				}. Response body: ${ JSON.stringify( await response.json() ) }`
 			);
 		}
 	}

--- a/src/api/window.d.ts
+++ b/src/api/window.d.ts
@@ -1,5 +1,0 @@
-/* eslint-disable no-var */
-export declare global {
-	var nonce: string;
-	var nonceHeaderName: string;
-}

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,5 +1,6 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { AppHeader } from '../app-header/app-header';
+import { useMonitoring } from '../monitoring/monitoring-provider';
 import { ReportingConfigLoadingIndicator } from '../reporting-config/reporting-config-loading-indicator';
 import { useReportingConfigLoad } from '../reporting-config/use-reporting-config';
 import { ReportingFlow } from '../reporting-flow/reporting-flow';
@@ -7,6 +8,11 @@ import styles from './app.module.css';
 
 export function App() {
 	const reportingConfigLoadStatus = useReportingConfigLoad();
+	const monitoringClient = useMonitoring();
+
+	useEffect( () => {
+		monitoringClient.analytics.recordEvent( 'page_view' );
+	}, [ monitoringClient.analytics ] );
 
 	let mainDisplay: ReactNode;
 	if ( reportingConfigLoadStatus === 'empty' || reportingConfigLoadStatus === 'loading' ) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,10 +8,22 @@ import { localMonitoringClient } from './monitoring/local-monitoring-client';
 import { localApiClient } from './api/local-api-client';
 import { MonitoringProvider } from './monitoring/monitoring-provider';
 import { ProductionApiClient } from './api/production-api-client';
+import { MonitoringClient } from './monitoring/types';
+import { ApiClient } from './api/types';
+import { createProductionMonitoringClient } from './monitoring/production-monitoring-client';
 
-// TODO: use a production monitoring client when it's actually implemented fully.
-const monitoringClient = isProduction() ? localMonitoringClient : localMonitoringClient;
-const apiClient = isProduction() ? new ProductionApiClient() : localApiClient;
+let apiClient: ApiClient;
+let monitoringClient: MonitoringClient;
+
+if ( isProduction() ) {
+	const productionApiClient = new ProductionApiClient();
+	apiClient = productionApiClient;
+	monitoringClient = createProductionMonitoringClient( productionApiClient );
+} else {
+	apiClient = localApiClient;
+	monitoringClient = localMonitoringClient;
+}
+
 const store = setupStore( apiClient );
 
 const root = ReactDOM.createRoot( document.getElementById( 'root' ) as HTMLElement );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,13 +5,13 @@ import { Provider } from 'react-redux';
 import { setupStore } from './app/store';
 import { App } from './app/app';
 import { localMonitoringClient } from './monitoring/local-monitoring-client';
-import { productionApiClient } from './api/production-api-client';
 import { localApiClient } from './api/local-api-client';
 import { MonitoringProvider } from './monitoring/monitoring-provider';
+import { ProductionApiClient } from './api/production-api-client';
 
 // TODO: use a production monitoring client when it's actually implemented fully.
 const monitoringClient = isProduction() ? localMonitoringClient : localMonitoringClient;
-const apiClient = isProduction() ? productionApiClient : localApiClient;
+const apiClient = isProduction() ? new ProductionApiClient() : localApiClient;
 const store = setupStore( apiClient );
 
 const root = ReactDOM.createRoot( document.getElementById( 'root' ) as HTMLElement );

--- a/src/monitoring/__tests__/production-monitoring-client.test.ts
+++ b/src/monitoring/__tests__/production-monitoring-client.test.ts
@@ -1,0 +1,157 @@
+/* eslint-disable testing-library/no-debugging-utils */
+import { createProductionMonitoringClient } from '../production-monitoring-client';
+
+describe( '[ProductionMonitoringClient]', () => {
+	const userRole = 'Code Wrangling';
+	function setup() {
+		// Reset these global variables so they can be manipulated in tests.
+		delete globalThis._tkq;
+		delete globalThis.enableDebugLogging;
+
+		// This can stay constant for all tests.
+		globalThis.userRole = userRole;
+
+		const mockConsole = {
+			debug: jest.spyOn( console, 'debug' ).mockImplementation( () => {
+				return;
+			} ),
+			error: jest.spyOn( console, 'error' ).mockImplementation( () => {
+				return;
+			} ),
+		};
+
+		const mockLoggingApiClient = {
+			log: jest.fn( () => Promise.resolve() ),
+		};
+		const productionMonitoringClient = createProductionMonitoringClient( mockLoggingApiClient );
+
+		return {
+			mockLoggingApiClient,
+			mockConsole,
+			productionMonitoringClient,
+		};
+	}
+
+	describe( 'Logger', () => {
+		test( 'debug() should not log when enableDebugLogging is undefined', () => {
+			const { productionMonitoringClient, mockConsole } = setup();
+
+			productionMonitoringClient.logger.debug( 'This is a debug message' );
+			expect( mockConsole.debug ).not.toHaveBeenCalled();
+		} );
+
+		test( 'debug() should not log when enableDebugLogging is false', () => {
+			const { productionMonitoringClient, mockConsole } = setup();
+			globalThis.enableDebugLogging = false;
+
+			productionMonitoringClient.logger.debug( 'This is a debug message' );
+			expect( mockConsole.debug ).not.toHaveBeenCalled();
+		} );
+
+		test( 'debug() should write to console when enableDebugLogging is true', () => {
+			const { productionMonitoringClient, mockConsole } = setup();
+			globalThis.enableDebugLogging = true;
+
+			const message = 'This is a debug message';
+			const properties = { foo: 'bar' };
+			productionMonitoringClient.logger.debug( message, properties );
+			expect( mockConsole.debug ).toHaveBeenCalledWith( message, properties );
+		} );
+
+		test( 'info() should log to the API with the correct payload', () => {
+			const { productionMonitoringClient, mockLoggingApiClient } = setup();
+
+			const message = 'This is an info message';
+			const properties = { foo: 'bar' };
+			productionMonitoringClient.logger.info( message, properties );
+			expect( mockLoggingApiClient.log ).toHaveBeenCalledWith( {
+				feature: 'bugomattic_client',
+				severity: 'info',
+				message,
+				properties,
+			} );
+		} );
+
+		test( 'If the logging API fails for info(), it should log to console.error', async () => {
+			const { productionMonitoringClient, mockLoggingApiClient, mockConsole } = setup();
+
+			let resolveErrorCallPromise = () => {
+				return;
+			};
+			const errorCallPromise = new Promise< void >( ( resolve ) => {
+				resolveErrorCallPromise = resolve;
+			} );
+
+			mockConsole.error.mockImplementationOnce( () => resolveErrorCallPromise() );
+
+			const errorMessage = 'API Error';
+			mockLoggingApiClient.log.mockImplementationOnce( async () => {
+				throw new Error( errorMessage );
+			} );
+
+			const message = 'This is an info message';
+			const properties = { foo: 'bar' };
+			productionMonitoringClient.logger.info( message, properties );
+
+			await errorCallPromise;
+
+			expect( mockConsole.error ).toHaveBeenCalledWith(
+				`Logging failed with error: ${ errorMessage }`
+			);
+			expect( mockConsole.error ).toHaveBeenCalledWith( 'Original log payload: ', {
+				feature: 'bugomattic_client',
+				severity: 'info',
+				message,
+				properties,
+			} );
+		} );
+
+		test( 'error() should log to the API with the correct payload', () => {
+			const { productionMonitoringClient, mockLoggingApiClient } = setup();
+
+			const message = 'This is an error message';
+			const properties = { foo: 'bar' };
+			productionMonitoringClient.logger.error( message, properties );
+			expect( mockLoggingApiClient.log ).toHaveBeenCalledWith( {
+				feature: 'bugomattic_client',
+				severity: 'error',
+				message,
+				properties,
+			} );
+		} );
+
+		test( 'If the logging API fails for error(), it should log to console.error', async () => {
+			const { productionMonitoringClient, mockLoggingApiClient, mockConsole } = setup();
+
+			let resolveErrorCallPromise = () => {
+				return;
+			};
+			const errorCallPromise = new Promise< void >( ( resolve ) => {
+				resolveErrorCallPromise = resolve;
+			} );
+
+			mockConsole.error.mockImplementationOnce( () => resolveErrorCallPromise() );
+
+			const errorMessage = 'API Error';
+			mockLoggingApiClient.log.mockImplementationOnce( async () => {
+				throw new Error( errorMessage );
+			} );
+
+			const message = 'This is an error message';
+			const properties = { foo: 'bar' };
+			productionMonitoringClient.logger.error( message, properties );
+
+			await errorCallPromise;
+
+			expect( mockConsole.error ).toHaveBeenCalledWith(
+				`Logging failed with error: ${ errorMessage }`
+			);
+			expect( mockConsole.error ).toHaveBeenCalledWith( 'Original log payload: ', {
+				feature: 'bugomattic_client',
+				severity: 'error',
+				message,
+				properties,
+			} );
+		} );
+	} );
+} );

--- a/src/monitoring/__tests__/production-monitoring-client.test.ts
+++ b/src/monitoring/__tests__/production-monitoring-client.test.ts
@@ -15,6 +15,9 @@ describe( '[ProductionMonitoringClient]', () => {
 			debug: jest.spyOn( console, 'debug' ).mockImplementation( () => {
 				return;
 			} ),
+			log: jest.spyOn( console, 'log' ).mockImplementation( () => {
+				return;
+			} ),
 			error: jest.spyOn( console, 'error' ).mockImplementation( () => {
 				return;
 			} ),
@@ -72,7 +75,7 @@ describe( '[ProductionMonitoringClient]', () => {
 			} );
 		} );
 
-		test( 'If the logging API fails for info(), it should log to console.error', async () => {
+		test( 'If the logging API fails for info(), it should log the error and original log', async () => {
 			const { productionMonitoringClient, mockLoggingApiClient, mockConsole } = setup();
 
 			let resolveErrorCallPromise = () => {
@@ -98,7 +101,7 @@ describe( '[ProductionMonitoringClient]', () => {
 			expect( mockConsole.error ).toHaveBeenCalledWith(
 				`Logging failed with error: ${ errorMessage }`
 			);
-			expect( mockConsole.error ).toHaveBeenCalledWith( 'Original log payload: ', {
+			expect( mockConsole.log ).toHaveBeenCalledWith( 'Original log payload: ', {
 				feature: 'bugomattic_client',
 				severity: 'info',
 				message,
@@ -120,7 +123,7 @@ describe( '[ProductionMonitoringClient]', () => {
 			} );
 		} );
 
-		test( 'If the logging API fails for error(), it should log to console.error', async () => {
+		test( 'If the logging API fails for error(), it should log the error and original log', async () => {
 			const { productionMonitoringClient, mockLoggingApiClient, mockConsole } = setup();
 
 			let resolveErrorCallPromise = () => {
@@ -146,7 +149,7 @@ describe( '[ProductionMonitoringClient]', () => {
 			expect( mockConsole.error ).toHaveBeenCalledWith(
 				`Logging failed with error: ${ errorMessage }`
 			);
-			expect( mockConsole.error ).toHaveBeenCalledWith( 'Original log payload: ', {
+			expect( mockConsole.log ).toHaveBeenCalledWith( 'Original log payload: ', {
 				feature: 'bugomattic_client',
 				severity: 'error',
 				message,

--- a/src/monitoring/__tests__/production-monitoring-client.test.ts
+++ b/src/monitoring/__tests__/production-monitoring-client.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable testing-library/no-debugging-utils */
 import { createProductionMonitoringClient } from '../production-monitoring-client';
+import { EventName } from '../types';
 
 describe( '[ProductionMonitoringClient]', () => {
 	const userRole = 'Code Wrangling';
@@ -155,6 +156,30 @@ describe( '[ProductionMonitoringClient]', () => {
 				message,
 				properties,
 			} );
+		} );
+	} );
+
+	describe( 'Analytics', () => {
+		test( 'calling recordEvent without properties pushes to the Tracks queue and adds the correct user role', () => {
+			const { productionMonitoringClient } = setup();
+
+			const eventName: EventName = 'feature_save';
+			productionMonitoringClient.analytics.recordEvent( eventName );
+
+			expect( globalThis._tkq ).toEqual( [
+				[ 'recordEvent', eventName, { user_role: userRole } ],
+			] );
+		} );
+
+		test( 'calling recordEvent with properties pushes to the Tracks queue and adds the correct user role', () => {
+			const { productionMonitoringClient } = setup();
+
+			const eventName: EventName = 'feature_save';
+			const properties = { foo: 'bar' };
+			productionMonitoringClient.analytics.recordEvent( eventName, properties );
+
+			const expectedProperties = { ...properties, user_role: userRole };
+			expect( globalThis._tkq ).toEqual( [ [ 'recordEvent', eventName, expectedProperties ] ] );
 		} );
 	} );
 } );

--- a/src/monitoring/__tests__/production-monitoring-client.test.ts
+++ b/src/monitoring/__tests__/production-monitoring-client.test.ts
@@ -167,7 +167,7 @@ describe( '[ProductionMonitoringClient]', () => {
 			productionMonitoringClient.analytics.recordEvent( eventName );
 
 			expect( globalThis._tkq ).toEqual( [
-				[ 'recordEvent', eventName, { user_role: userRole } ],
+				[ 'recordEvent', `mc_bugomattic_new_${ eventName }`, { user_role: userRole } ],
 			] );
 		} );
 
@@ -179,7 +179,9 @@ describe( '[ProductionMonitoringClient]', () => {
 			productionMonitoringClient.analytics.recordEvent( eventName, properties );
 
 			const expectedProperties = { ...properties, user_role: userRole };
-			expect( globalThis._tkq ).toEqual( [ [ 'recordEvent', eventName, expectedProperties ] ] );
+			expect( globalThis._tkq ).toEqual( [
+				[ 'recordEvent', `mc_bugomattic_new_${ eventName }`, expectedProperties ],
+			] );
 		} );
 	} );
 } );

--- a/src/monitoring/production-monitoring-client.ts
+++ b/src/monitoring/production-monitoring-client.ts
@@ -1,24 +1,82 @@
-import { AnalyticsClient, LoggerClient, MonitoringClient } from './types';
+import {
+	AdditionalLogDetails,
+	AnalyticsClient,
+	EventName,
+	EventProperties,
+	LoggerClient,
+	LoggingApiClient as LoggerApiClient,
+	LoggingPayload,
+	MonitoringClient,
+} from './types';
 
-const productionLogger: LoggerClient = {
-	debug: ( message, additionalDetails? ) => {
-		throw new Error( 'Not implemented' );
-	},
-	info: ( message, additionalDetails? ) => {
-		throw new Error( 'Not implemented' );
-	},
-	error: ( message, additionalDetails? ) => {
-		throw new Error( 'Not implemented' );
-	},
-};
+class ProducutionLoggerClient implements LoggerClient {
+	private client: LoggerApiClient;
+	constructor( client: LoggerApiClient ) {
+		this.client = client;
+	}
 
-const productionAnalytics: AnalyticsClient = {
-	recordEvent: ( eventName, properties? ) => {
-		throw new Error( 'Not implemented' );
-	},
-};
+	private logFailureToConsole( error: Error, originalLogPayload: LoggingPayload ): void {
+		const logError = console.error || console.log;
+		logError( `Logging failed with error: ${ error.message }` );
+		logError( 'Original log payload: ', originalLogPayload );
+	}
 
-export const productionMonitoringClient: MonitoringClient = {
-	logger: productionLogger,
-	analytics: productionAnalytics,
-};
+	debug( message: string, additionalDetails?: AdditionalLogDetails ): void {
+		// Don't cache this as a private member variable because we want people to be able to change it at runtime.
+		if ( ! globalThis.enableDebugLogging ) {
+			return;
+		}
+
+		const log = console.debug || console.log;
+		log( message, additionalDetails || '' );
+	}
+
+	info( message: string, additionalDetails?: AdditionalLogDetails ): void {
+		const logPayload: LoggingPayload = {
+			feature: 'bugomattic_client',
+			severity: 'info',
+			message,
+			properties: additionalDetails,
+		};
+		this.client.log( logPayload ).catch( ( error ) => {
+			this.logFailureToConsole( error, logPayload );
+		} );
+	}
+
+	error( message: string, additionalDetails?: AdditionalLogDetails ): void {
+		const logPayload: LoggingPayload = {
+			feature: 'bugomattic_client',
+			severity: 'error',
+			message,
+			properties: additionalDetails,
+		};
+		this.client.log( logPayload ).catch( ( error ) => {
+			this.logFailureToConsole( error, logPayload );
+		} );
+	}
+}
+
+class ProductionAnalyticsClient implements AnalyticsClient {
+	private userRole: string;
+	constructor() {
+		globalThis._tkq = globalThis._tkq || [];
+		this.userRole = globalThis.userRole;
+	}
+
+	recordEvent( eventName: EventName, properties?: EventProperties ): void {
+		if ( ! properties ) {
+			properties = {};
+		}
+		properties.user_role = this.userRole;
+		globalThis._tkq?.push( [ 'recordEvent', eventName, properties ] );
+	}
+}
+
+export function createProductionMonitoringClient(
+	loggerApiClient: LoggerApiClient
+): MonitoringClient {
+	return {
+		logger: new ProducutionLoggerClient( loggerApiClient ),
+		analytics: new ProductionAnalyticsClient(),
+	};
+}

--- a/src/monitoring/production-monitoring-client.ts
+++ b/src/monitoring/production-monitoring-client.ts
@@ -4,8 +4,8 @@ import {
 	EventName,
 	EventProperties,
 	LoggerClient,
-	LoggingApiClient as LoggerApiClient,
-	LoggingPayload,
+	LoggerApiClient,
+	LogPayload,
 	MonitoringClient,
 } from './types';
 
@@ -15,10 +15,10 @@ class ProducutionLoggerClient implements LoggerClient {
 		this.client = client;
 	}
 
-	private logFailureToConsole( error: Error, originalLogPayload: LoggingPayload ): void {
+	private logFailureToConsole( error: Error, originalLogPayload: LogPayload ): void {
 		const logError = console.error || console.log;
 		logError( `Logging failed with error: ${ error.message }` );
-		logError( 'Original log payload: ', originalLogPayload );
+		console.log( 'Original log payload: ', originalLogPayload );
 	}
 
 	debug( message: string, additionalDetails?: AdditionalLogDetails ): void {
@@ -32,7 +32,7 @@ class ProducutionLoggerClient implements LoggerClient {
 	}
 
 	info( message: string, additionalDetails?: AdditionalLogDetails ): void {
-		const logPayload: LoggingPayload = {
+		const logPayload: LogPayload = {
 			feature: 'bugomattic_client',
 			severity: 'info',
 			message,
@@ -44,7 +44,7 @@ class ProducutionLoggerClient implements LoggerClient {
 	}
 
 	error( message: string, additionalDetails?: AdditionalLogDetails ): void {
-		const logPayload: LoggingPayload = {
+		const logPayload: LogPayload = {
 			feature: 'bugomattic_client',
 			severity: 'error',
 			message,

--- a/src/monitoring/production-monitoring-client.ts
+++ b/src/monitoring/production-monitoring-client.ts
@@ -64,11 +64,12 @@ class ProductionAnalyticsClient implements AnalyticsClient {
 	}
 
 	recordEvent( eventName: EventName, properties?: EventProperties ): void {
+		const prefix = 'mc_bugomattic_new';
 		if ( ! properties ) {
 			properties = {};
 		}
 		properties.user_role = this.userRole;
-		globalThis._tkq?.push( [ 'recordEvent', eventName, properties ] );
+		globalThis._tkq?.push( [ 'recordEvent', `${ prefix }_${ eventName }`, properties ] );
 	}
 }
 

--- a/src/monitoring/types.ts
+++ b/src/monitoring/types.ts
@@ -39,13 +39,13 @@ export type EventName =
 	| 'task_link_click'
 	| 'more_info_link_click';
 
-export interface LoggingPayload {
+export interface LogPayload {
 	feature: 'bugomattic_client';
 	severity: 'info' | 'error';
 	message: string;
 	properties?: AdditionalLogDetails;
 }
 
-export interface LoggingApiClient {
-	log( payload: LoggingPayload ): Promise< void >;
+export interface LoggerApiClient {
+	log( payload: LogPayload ): Promise< void >;
 }

--- a/src/monitoring/types.ts
+++ b/src/monitoring/types.ts
@@ -28,6 +28,8 @@ export interface AnalyticsClient {
 
 export type EventName =
 	| 'page_view'
+	| 'feature_select'
+	| 'feature_clear'
 	| 'feature_search'
 	| 'feature_save'
 	| 'title_save'

--- a/src/monitoring/types.ts
+++ b/src/monitoring/types.ts
@@ -1,4 +1,4 @@
-interface AdditionalLogDetails {
+export interface AdditionalLogDetails {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[ key: string ]: any;
 }
@@ -7,7 +7,7 @@ interface LogFunction {
 	( message: string, additionalDetails?: AdditionalLogDetails ): void;
 }
 
-interface EventProperties {
+export interface EventProperties {
 	[ key: string ]: number | string;
 }
 
@@ -23,5 +23,29 @@ export interface LoggerClient {
 }
 
 export interface AnalyticsClient {
-	recordEvent( eventName: string, properties?: EventProperties ): void;
+	recordEvent( eventName: EventName, properties?: EventProperties ): void;
+}
+
+export type EventName =
+	| 'page_view'
+	| 'feature_search'
+	| 'feature_save'
+	| 'title_save'
+	| 'type_save'
+	| 'feature_step_edit'
+	| 'type_step_edit'
+	| 'task_complete'
+	| 'task_complete_all'
+	| 'task_link_click'
+	| 'more_info_link_click';
+
+export interface LoggingPayload {
+	feature: 'bugomattic_client';
+	severity: 'info' | 'error';
+	message: string;
+	properties?: AdditionalLogDetails;
+}
+
+export interface LoggingApiClient {
+	log( payload: LoggingPayload ): Promise< void >;
 }

--- a/src/next-steps/next-steps.tsx
+++ b/src/next-steps/next-steps.tsx
@@ -9,7 +9,6 @@ import { selectIssueFeatureId } from '../issue-details/issue-details-slice';
 import { selectAllTasksAreComplete } from '../combined-selectors/all-tasks-are-complete';
 import { useMonitoring } from '../monitoring/monitoring-provider';
 import { selectNormalizedReportingConfig } from '../reporting-config/reporting-config-slice';
-import { TaskParentEntityType } from '../reporting-config/types';
 
 export function NextSteps() {
 	const monitoringClient = useMonitoring();
@@ -25,12 +24,8 @@ export function NextSteps() {
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
 
 	useEffect( () => {
-		const taskSources: {
-			[ taskId: string ]: { parentType: TaskParentEntityType; parentId: string };
-		} = {};
-
-		relevantTaskIds.forEach( ( taskId ) => {
-			taskSources[ taskId ] = {
+		const sourcesInOrder = relevantTaskIds.map( ( taskId ) => {
+			return {
 				parentType: tasks[ taskId ].parentType,
 				parentId: tasks[ taskId ].parentId,
 			};
@@ -38,7 +33,7 @@ export function NextSteps() {
 
 		monitoringClient.logger.debug(
 			'Relevant tasks calculated for issue type and feature. See additional details for sourcing.',
-			{ sources: taskSources }
+			{ sourcesInOrder }
 		);
 	}, [ relevantTaskIds, tasks, monitoringClient.logger ] );
 

--- a/src/next-steps/next-steps.tsx
+++ b/src/next-steps/next-steps.tsx
@@ -7,16 +7,40 @@ import { MoreInfo } from './sub-components/more-info';
 import Confetti from 'react-confetti';
 import { selectIssueFeatureId } from '../issue-details/issue-details-slice';
 import { selectAllTasksAreComplete } from '../combined-selectors/all-tasks-are-complete';
+import { useMonitoring } from '../monitoring/monitoring-provider';
+import { selectNormalizedReportingConfig } from '../reporting-config/reporting-config-slice';
+import { TaskParentEntityType } from '../reporting-config/types';
 
 export function NextSteps() {
+	const monitoringClient = useMonitoring();
+
 	const sectionRef = useRef< HTMLElement >( null );
 	const [ sectionWidth, setSectionWidth ] = useState( 0 );
 	const [ sectionHeight, setSectionHeight ] = useState( 0 );
 	const [ showConfetti, setShowConfetti ] = useState( false );
 
+	const { tasks } = useAppSelector( selectNormalizedReportingConfig );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 	const relevantTaskIds = useAppSelector( selectRelevantTaskIds );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
+
+	useEffect( () => {
+		const taskSources: {
+			[ taskId: string ]: { parentType: TaskParentEntityType; parentId: string };
+		} = {};
+
+		relevantTaskIds.forEach( ( taskId ) => {
+			taskSources[ taskId ] = {
+				parentType: tasks[ taskId ].parentType,
+				parentId: tasks[ taskId ].parentId,
+			};
+		} );
+
+		monitoringClient.logger.debug(
+			'Relevant tasks calculated for issue type and feature. See additional details for sourcing.',
+			{ sources: taskSources }
+		);
+	}, [ relevantTaskIds, tasks, monitoringClient.logger ] );
 
 	const updateSizes = () => {
 		if ( sectionRef.current ) {

--- a/src/next-steps/sub-components/task.tsx
+++ b/src/next-steps/sub-components/task.tsx
@@ -73,7 +73,7 @@ export function Task( { taskId }: Props ) {
 		} catch ( err ) {
 			const error = err as Error;
 			monitoringClient.logger.error( 'Task link has broken configuration', {
-				task_id: taskId,
+				taskId,
 				error: error.message,
 			} );
 

--- a/src/next-steps/sub-components/task.tsx
+++ b/src/next-steps/sub-components/task.tsx
@@ -19,6 +19,7 @@ import {
 	createP2Href,
 	createSlackHref,
 } from '../../common/lib';
+import { useMonitoring } from '../../monitoring/monitoring-provider';
 
 interface Props {
 	taskId: string;
@@ -26,6 +27,7 @@ interface Props {
 
 export function Task( { taskId }: Props ) {
 	const dispatch = useAppDispatch();
+	const monitoringClient = useMonitoring();
 	const { tasks } = useAppSelector( selectNormalizedReportingConfig );
 	const { issueTitle } = useAppSelector( selectIssueDetails );
 	const completedTaskIds = useAppSelector( selectCompletedTasks );
@@ -68,8 +70,13 @@ export function Task( { taskId }: Props ) {
 					<LinkIcon aria-hidden={ true } className={ styles.linkIcon } />
 				</a>
 			);
-		} catch ( error ) {
-			// TODO: log the error with our monitoring client
+		} catch ( err ) {
+			const error = err as Error;
+			monitoringClient.logger.error( 'Task link has broken configuration', {
+				task_id: taskId,
+				error: error.message,
+			} );
+
 			taskIsBroken = true;
 			titleDisplay = (
 				<span className={ styles.badTask }>

--- a/src/test-utils/mock-monitoring-client.ts
+++ b/src/test-utils/mock-monitoring-client.ts
@@ -1,0 +1,12 @@
+export function createMockMonitoringClient() {
+	return {
+		logger: {
+			debug: jest.fn(),
+			info: jest.fn(),
+			error: jest.fn(),
+		},
+		analytics: {
+			recordEvent: jest.fn(),
+		},
+	};
+}

--- a/src/test-utils/render-with-providers.tsx
+++ b/src/test-utils/render-with-providers.tsx
@@ -6,6 +6,9 @@ import { Provider } from 'react-redux';
 import { setupStore } from '../app/store';
 import type { AppStore, RootState } from '../app/store';
 import { ApiClient } from '../api/types';
+import { MonitoringClient } from '../monitoring/types';
+import { createMockMonitoringClient } from './mock-monitoring-client';
+import { MonitoringProvider } from '../monitoring/monitoring-provider';
 
 // This is a common pattern for overriding React Testing Library's 'render'
 // function while hydrating in a redux store (and in our case, an API implementation).
@@ -15,6 +18,7 @@ import { ApiClient } from '../api/types';
 // as allows the user to specify other things such as initialState, store.
 interface ExtendedRenderOptions extends Omit< RenderOptions, 'queries' > {
 	apiClient: ApiClient;
+	monitoringClient?: MonitoringClient;
 	preloadedState?: PreloadedState< RootState >;
 	store?: AppStore;
 }
@@ -30,13 +34,18 @@ export function renderWithProviders(
 	component: ReactElement,
 	{
 		apiClient,
+		monitoringClient = createMockMonitoringClient(),
 		preloadedState = {},
 		store = setupStore( apiClient, preloadedState ),
 		...renderOptions
 	}: ExtendedRenderOptions
 ) {
 	function Wrapper( { children }: PropsWithChildren< {} > ): JSX.Element {
-		return <Provider store={ store }>{ children }</Provider>;
+		return (
+			<MonitoringProvider monitoringClient={ monitoringClient }>
+				<Provider store={ store }>{ children }</Provider>
+			</MonitoringProvider>
+		);
 	}
 
 	return { store, ...render( component, { wrapper: Wrapper, ...renderOptions } ) };

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable no-var */
+export declare global {
+	var nonce: string;
+	var nonceHeaderName: string;
+	var userRole: string;
+	var enableDebugLogging: boolean | undefined;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	var _tkq: any[] | undefined;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2126,6 +2126,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@miragejs/pretender-node-polyfill@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "@miragejs/pretender-node-polyfill@npm:0.1.2"
+  checksum: bb55983a253dc0d4162acac090b062500595c9844bfbd21fe25bc1f926808d0070d710e622aa6285fa16c673a65cf3e05f4b32e888c469f1bde8888a7934ee44
+  languageName: node
+  linkType: hard
+
 "@nicolo-ribaudo/eslint-scope-5-internals@npm:5.1.1-v1":
   version: 5.1.1-v1
   resolution: "@nicolo-ribaudo/eslint-scope-5-internals@npm:5.1.1-v1"
@@ -4179,6 +4186,7 @@ __metadata:
     jest-environment-jsdom: ^27.4.3
     lint-staged: ^13.0.3
     lodash.debounce: ^4.0.8
+    miragejs: ^0.1.47
     path-browserify: ^1.0.1
     prettier: "npm:wp-prettier@latest"
     react: ^18.2.0
@@ -6458,6 +6466,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fake-xml-http-request@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "fake-xml-http-request@npm:2.1.2"
+  checksum: 7b1ebea1955c46cbda0e0c3308716cc82beca7bb6c549f1d1c2a8134203c9d6c5a21194e2c1e17650ff073ecbcd3e56cf1e21f248a86cbcb3567fd7a9ca4850e
+  languageName: node
+  linkType: hard
+
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -7513,6 +7528,13 @@ __metadata:
   version: 1.0.4
   resolution: "infer-owner@npm:1.0.4"
   checksum: 181e732764e4a0611576466b4b87dac338972b839920b2a8cde43642e4ed6bd54dc1fb0b40874728f2a2df9a1b097b8ff83b56d5f8f8e3927f837fdcb47d8a89
+  languageName: node
+  linkType: hard
+
+"inflected@npm:^2.0.4":
+  version: 2.1.0
+  resolution: "inflected@npm:2.1.0"
+  checksum: 1e3fb2d24ec6c774977dd5ed884c6097b6525f66edecfdca0845ab4023d35f02af1057de50cd69cdc5829d0bd5ba69fd7fb41d4d8abdf85ee243bf2bbf65995d
   languageName: node
   linkType: hard
 
@@ -9020,10 +9042,136 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.assign@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.assign@npm:4.2.0"
+  checksum: 75bbc6733c9f577c448031b4051f990f068802708891f94be9d4c2faffd6a9ec67a2c49671dafc908a068d35687765464853282842b4560b662e6c903d11cc90
+  languageName: node
+  linkType: hard
+
+"lodash.camelcase@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.camelcase@npm:4.3.0"
+  checksum: cb9227612f71b83e42de93eccf1232feeb25e705bdb19ba26c04f91e885bfd3dd5c517c4a97137658190581d3493ea3973072ca010aab7e301046d90740393d1
+  languageName: node
+  linkType: hard
+
+"lodash.clonedeep@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.clonedeep@npm:4.5.0"
+  checksum: 92c46f094b064e876a23c97f57f81fbffd5d760bf2d8a1c61d85db6d1e488c66b0384c943abee4f6af7debf5ad4e4282e74ff83177c9e63d8ff081a4837c3489
+  languageName: node
+  linkType: hard
+
+"lodash.compact@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "lodash.compact@npm:3.0.1"
+  checksum: 75039eddfa5ef2ea0da1fc3d36515e92227241f94258b3dcf771196e741c878698ce5b79c0cb7fe758841c9dfd0e6fa222888985aadc0384fd79bbc9680dd829
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
+  languageName: node
+  linkType: hard
+
+"lodash.find@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.find@npm:4.6.0"
+  checksum: b737f849a4fe36f5c3664ea636780dda2fde18335021faf80cdfdcb300ed75441da6f55cfd6de119092d8bb2ddbc4433f4a8de4b99c0b9c8640465b0901c717c
+  languageName: node
+  linkType: hard
+
+"lodash.flatten@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.flatten@npm:4.4.0"
+  checksum: 0ac34a393d4b795d4b7421153d27c13ae67e08786c9cbb60ff5b732210d46f833598eee3fb3844bb10070e8488efe390ea53bb567377e0cb47e9e630bf0811cb
+  languageName: node
+  linkType: hard
+
+"lodash.forin@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.forin@npm:4.4.0"
+  checksum: c9c8e6c3204029fe0610efb8c74113b00a3d5a92b1d8defbf3f5cbc2d0f7663c680dff62e2950ed9406bb6d06e882fa39568c607bc44229d53fd93a9fd6c07b7
+  languageName: node
+  linkType: hard
+
+"lodash.get@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
+  languageName: node
+  linkType: hard
+
+"lodash.has@npm:^4.5.2":
+  version: 4.5.2
+  resolution: "lodash.has@npm:4.5.2"
+  checksum: b3ec829a86852331d48b3730ff06088a283d128a3965aa521ffd942bcf5c82e06bed3164ff7a7751d11e768d88f0d7bab316192091489caf20f452d42f7055d5
+  languageName: node
+  linkType: hard
+
+"lodash.invokemap@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.invokemap@npm:4.6.0"
+  checksum: 646ceebbefbcb6da301f8c2868254680fd0bcdc6ada470495d9ae49c9c32938829c1b38a38c95d0258409a9655f85db404b16e648381c7450b7ed3d9c52d8808
+  languageName: node
+  linkType: hard
+
+"lodash.isempty@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.isempty@npm:4.4.0"
+  checksum: a8118f23f7ed72a1dbd176bf27f297d1e71aa1926288449cb8f7cef99ba1bc7527eab52fe7899ab080fa1dc150aba6e4a6367bf49fa4e0b78da1ecc095f8d8c5
+  languageName: node
+  linkType: hard
+
+"lodash.isequal@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: da27515dc5230eb1140ba65ff8de3613649620e8656b19a6270afe4866b7bd461d9ba2ac8a48dcc57f7adac4ee80e1de9f965d89d4d81a0ad52bb3eec2609644
+  languageName: node
+  linkType: hard
+
+"lodash.isfunction@npm:^3.0.9":
+  version: 3.0.9
+  resolution: "lodash.isfunction@npm:3.0.9"
+  checksum: 99e54c34b1e8a9ba75c034deb39cedbd2aca7af685815e67a2a8ec4f73ec9748cda6ebee5a07d7de4b938e90d421fd280e9c385cc190f903ac217ac8aff30314
+  languageName: node
+  linkType: hard
+
+"lodash.isinteger@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "lodash.isinteger@npm:4.0.4"
+  checksum: 6034821b3fc61a2ffc34e7d5644bb50c5fd8f1c0121c554c21ac271911ee0c0502274852845005f8651d51e199ee2e0cfebfe40aaa49c7fe617f603a8a0b1691
+  languageName: node
+  linkType: hard
+
+"lodash.isplainobject@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "lodash.isplainobject@npm:4.0.6"
+  checksum: 29c6351f281e0d9a1d58f1a4c8f4400924b4c79f18dfc4613624d7d54784df07efaff97c1ff2659f3e085ecf4fff493300adc4837553104cef2634110b0d5337
+  languageName: node
+  linkType: hard
+
+"lodash.lowerfirst@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "lodash.lowerfirst@npm:4.3.1"
+  checksum: e1688e18873777d394db4994d150dfc14cf01bf450169cf8296af4d84ecd7c3c4ae4dab3746f77f8719a093e4fff58bee3ae73ae7e23ef508b7d970b189d9952
+  languageName: node
+  linkType: hard
+
+"lodash.map@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.map@npm:4.6.0"
+  checksum: 7369a41d7d24d15ce3bbd02a7faa3a90f6266c38184e64932571b9b21b758bd10c04ffd117d1859be1a44156f29b94df5045eff172bf8a97fddf68bf1002d12f
+  languageName: node
+  linkType: hard
+
+"lodash.mapvalues@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "lodash.mapvalues@npm:4.6.0"
+  checksum: 0ff1b252fda318fc36e47c296984925e98fbb0fc5a2ecc4ef458f3c739a9476d47e40c95ac653e8314d132aa59c746d4276527b99d6e271940555c6e12d2babd
   languageName: node
   linkType: hard
 
@@ -9041,6 +9189,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.pick@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.pick@npm:4.4.0"
+  checksum: 2c36cab7da6b999a20bd3373b40e31a3ef81fa264f34a6979c852c5bc8ac039379686b27380f0cb8e3781610844fafec6949c6fbbebc059c98f8fa8570e3675f
+  languageName: node
+  linkType: hard
+
+"lodash.snakecase@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "lodash.snakecase@npm:4.1.1"
+  checksum: 1685ed3e83dda6eae5a4dcaee161a51cd210aabb3e1c09c57150e7dd8feda19e4ca0d27d0631eabe8d0f4eaa51e376da64e8c018ae5415417c5890d42feb72a8
+  languageName: node
+  linkType: hard
+
 "lodash.sortby@npm:^4.7.0":
   version: 4.7.0
   resolution: "lodash.sortby@npm:4.7.0"
@@ -9052,6 +9214,20 @@ __metadata:
   version: 4.5.0
   resolution: "lodash.uniq@npm:4.5.0"
   checksum: a4779b57a8d0f3c441af13d9afe7ecff22dd1b8ce1129849f71d9bbc8e8ee4e46dfb4b7c28f7ad3d67481edd6e51126e4e2a6ee276e25906d10f7140187c392d
+  languageName: node
+  linkType: hard
+
+"lodash.uniqby@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "lodash.uniqby@npm:4.7.0"
+  checksum: 659264545a95726d1493123345aad8cbf56e17810fa9a0b029852c6d42bc80517696af09d99b23bef1845d10d95e01b8b4a1da578f22aeba7a30d3e0022a4938
+  languageName: node
+  linkType: hard
+
+"lodash.values@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.values@npm:4.3.0"
+  checksum: 857e122ddf6edb50137887f0b834d471f96d66692ebb5de8b048ed277c8a3dd1bc8f85d82cf31b0f5c6dbc5b72c036a591205f76eec86bb11818a1a6f7e5a28c
   languageName: node
   linkType: hard
 
@@ -9470,6 +9646,40 @@ __metadata:
     minipass: ^3.0.0
     yallist: ^4.0.0
   checksum: f1fdeac0b07cf8f30fcf12f4b586795b97be856edea22b5e9072707be51fc95d41487faec3f265b42973a304fe3a64acd91a44a3826a963e37b37bafde0212c3
+  languageName: node
+  linkType: hard
+
+"miragejs@npm:^0.1.47":
+  version: 0.1.47
+  resolution: "miragejs@npm:0.1.47"
+  dependencies:
+    "@miragejs/pretender-node-polyfill": ^0.1.0
+    inflected: ^2.0.4
+    lodash.assign: ^4.2.0
+    lodash.camelcase: ^4.3.0
+    lodash.clonedeep: ^4.5.0
+    lodash.compact: ^3.0.1
+    lodash.find: ^4.6.0
+    lodash.flatten: ^4.4.0
+    lodash.forin: ^4.4.0
+    lodash.get: ^4.4.2
+    lodash.has: ^4.5.2
+    lodash.invokemap: ^4.6.0
+    lodash.isempty: ^4.4.0
+    lodash.isequal: ^4.5.0
+    lodash.isfunction: ^3.0.9
+    lodash.isinteger: ^4.0.4
+    lodash.isplainobject: ^4.0.6
+    lodash.lowerfirst: ^4.3.1
+    lodash.map: ^4.6.0
+    lodash.mapvalues: ^4.6.0
+    lodash.pick: ^4.4.0
+    lodash.snakecase: ^4.1.1
+    lodash.uniq: ^4.5.0
+    lodash.uniqby: ^4.7.0
+    lodash.values: ^4.3.0
+    pretender: ^3.4.7
+  checksum: b50cd640c07bdd2a05df20c5113685818c3c6c63a00af2b9ac59f7ba3bd1da4e2fbe5a9cf11ca7c635c4b2e66d5585704f1dae2d48d06096b9d58d0c57ebf087
   languageName: node
   linkType: hard
 
@@ -11086,6 +11296,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretender@npm:^3.4.7":
+  version: 3.4.7
+  resolution: "pretender@npm:3.4.7"
+  dependencies:
+    fake-xml-http-request: ^2.1.2
+    route-recognizer: ^0.3.3
+  checksum: ca767dfa3fdb5e49cec8f272de1c7d489f53986a9f58dd0caf379b6365b1f1241bbb03bea6fe4421ce3e2aaa894d6c7349a5ef603283710be2babca49f1ad6fb
+  languageName: node
+  linkType: hard
+
 "prettier-linter-helpers@npm:^1.0.0":
   version: 1.0.0
   resolution: "prettier-linter-helpers@npm:1.0.0"
@@ -12616,6 +12836,13 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 6a2bf167b3587d4df709b37d149ad0300692cc5deb510f89ac7bdc77c8738c9546ae3de9322b0968e1ed2b0e984571f5f55aae28fa7de4cfcb1bc5402a4e2be6
+  languageName: node
+  linkType: hard
+
+"route-recognizer@npm:^0.3.3":
+  version: 0.3.4
+  resolution: "route-recognizer@npm:0.3.4"
+  checksum: 9586704491b26716eba1bdbb4a386893ecaab80c6dbf34e394957063b941ebf336ca09222f0892c9d118c609fa9b972d6e73e454abd4382acdc34dbb878e87f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### What Does This PR Add/Change?

Adds the production implementation of the monitoring client, which handles logging and analytics (Tracks events).

This doesn't include fully using that monitoring client throughout the app. That will come in a later PR! For now, we just include a few sample places.

#### Testing Instructions

This in many ways depends on backend changes that may/may not be there.

So for now, the best way to test this is with unit tests! 

`yarn test:once`

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #