### PR TITLE
Add remaining Tracks events

### DIFF
--- a/src/app/__tests__/app.test.tsx
+++ b/src/app/__tests__/app.test.tsx
@@ -96,4 +96,15 @@ describe( '[app]', () => {
 			}
 		);
 	} );
+
+	test( 'On loading, records the "page_view" event', async () => {
+		const apiClient = createMockApiClient();
+
+		const { monitoringClient } = setup( <App />, apiClient );
+
+		await waitForElementToBeRemoved( () =>
+			screen.queryByRole( 'alert', { name: 'Loading issue reporting configuration' } )
+		);
+		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'page_view' );
+	} );
 } );

--- a/src/combined-selectors/all-tasks-are-complete.ts
+++ b/src/combined-selectors/all-tasks-are-complete.ts
@@ -1,16 +1,34 @@
 import { createSelector } from '@reduxjs/toolkit';
+import { RootState } from '../app/store';
 import { selectCompletedTasks } from '../next-steps/completed-tasks-slice';
 import { selectRelevantTaskIds } from './relevant-task-ids';
 
 export const selectAllTasksAreComplete = createSelector(
 	[ selectRelevantTaskIds, selectCompletedTasks ],
 	( relevantTaskIds, completedTaskIds ) => {
-		const completedTaskIdsSet = new Set( completedTaskIds );
-		for ( const taskId of relevantTaskIds ) {
-			if ( ! completedTaskIdsSet.has( taskId ) ) {
-				return false;
-			}
-		}
-		return true;
+		return allTasksAreComplete( relevantTaskIds, completedTaskIds );
 	}
 );
+
+export const makeSelectorToPredictCompletingAllTasks = () =>
+	createSelector(
+		[
+			selectRelevantTaskIds,
+			selectCompletedTasks,
+			( _state: RootState, currentTaskId: string ) => currentTaskId,
+		],
+		( relevantTaskIds, completedTaskIds, currentTaskId ) => {
+			const expectedCompletedTasks = [ ...completedTaskIds, currentTaskId ];
+			return allTasksAreComplete( relevantTaskIds, expectedCompletedTasks );
+		}
+	);
+
+function allTasksAreComplete( relevantTaskIds: string[], completedTaskIds: string[] ) {
+	const completedTaskIdsSet = new Set( completedTaskIds );
+	for ( const taskId of relevantTaskIds ) {
+		if ( ! completedTaskIdsSet.has( taskId ) ) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
@@ -194,7 +194,7 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 		);
 	} );
 
-	test( 'Selecting a feature records the "feature_select" event', async () => {
+	test( 'Selecting a feature records the "feature_select" event with product name', async () => {
 		const { user, monitoringClient } = setup( <FeatureSelectorForm /> );
 
 		await expandAll( user );
@@ -202,7 +202,9 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 			screen.getByRole( 'option', { selected: false, description: featureUnderGroup.description } )
 		);
 
-		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_select' );
+		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_select', {
+			productName: 'Test Product',
+		} );
 	} );
 
 	test( 'Clicking continue before selecting a feature shows form error', async () => {

--- a/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
@@ -194,7 +194,7 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 		);
 	} );
 
-	test( 'Selecting a feature records the "feature_select" event with product name', async () => {
+	test( 'Selecting a feature records the "feature_select" event with feature and product name', async () => {
 		const { user, monitoringClient } = setup( <FeatureSelectorForm /> );
 
 		await expandAll( user );
@@ -203,7 +203,8 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 		);
 
 		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_select', {
-			productName: 'Test Product',
+			productName: product.name,
+			featureName: featureUnderGroup.name,
 		} );
 	} );
 
@@ -270,7 +271,7 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_clear' );
 	} );
 
-	test( 'Clicking continue with a selected feature records the "feature_save" event with product name', async () => {
+	test( 'Clicking continue with a selected feature records the "feature_save" event with feature and product name', async () => {
 		const { user, monitoringClient } = setup( <FeatureSelectorForm /> );
 
 		await expandAll( user );
@@ -281,6 +282,7 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 
 		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_save', {
 			productName: product.name,
+			featureName: featureUnderGroup.name,
 		} );
 	} );
 } );

--- a/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
@@ -11,6 +11,7 @@ import { FeatureSelectorForm } from '../feature-selector-form';
 import { createMockApiClient } from '../../test-utils/mock-api-client';
 import { renderWithProviders } from '../../test-utils/render-with-providers';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
+import { createMockMonitoringClient } from '../../test-utils/mock-monitoring-client';
 
 describe( '[FeatureSelector -- Feature Selection]', () => {
 	// NOTE! Because we have descriptions here, we will be affected by this bug...
@@ -64,9 +65,11 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 
 	function setup( component: ReactElement ) {
 		const apiClient = createMockApiClient();
+		const monitoringClient = createMockMonitoringClient();
 		const user = userEvent.setup();
 		const view = renderWithProviders( component, {
 			apiClient,
+			monitoringClient,
 			preloadedState: {
 				reportingConfig: {
 					normalized: reportingConfig,
@@ -80,6 +83,7 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 
 		return {
 			user,
+			monitoringClient,
 			...view,
 		};
 	}
@@ -190,6 +194,17 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 		);
 	} );
 
+	test( 'Selecting a feature records the "feature_select" event', async () => {
+		const { user, monitoringClient } = setup( <FeatureSelectorForm /> );
+
+		await expandAll( user );
+		await user.click(
+			screen.getByRole( 'option', { selected: false, description: featureUnderGroup.description } )
+		);
+
+		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_select' );
+	} );
+
 	test( 'Clicking continue before selecting a feature shows form error', async () => {
 		const { user } = setup( <FeatureSelectorForm /> );
 
@@ -239,5 +254,31 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 				return content === featureUnderProduct.name && element?.className === 'selectedFeatureName';
 			} )
 		).not.toBeInTheDocument();
+	} );
+
+	test( 'Clicking the clear button records the "feature_clear" event', async () => {
+		const { user, monitoringClient } = setup( <FeatureSelectorForm /> );
+
+		await expandAll( user );
+		await user.click(
+			screen.getByRole( 'option', { selected: false, description: featureUnderGroup.description } )
+		);
+		await user.click( screen.getByRole( 'button', { name: 'Clear currently selected feature' } ) );
+
+		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_clear' );
+	} );
+
+	test( 'Clicking continue with a selected feature records the "feature_save" event with product name', async () => {
+		const { user, monitoringClient } = setup( <FeatureSelectorForm /> );
+
+		await expandAll( user );
+		await user.click(
+			screen.getByRole( 'option', { selected: false, description: featureUnderGroup.description } )
+		);
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( monitoringClient.analytics.recordEvent ).toHaveBeenCalledWith( 'feature_save', {
+			productName: product.name,
+		} );
 	} );
 } );

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -35,11 +35,12 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 
 	const selectedFeatureId = useAppSelector( selectSelectedFeatureId );
 
-	const { products } = useAppSelector( selectNormalizedReportingConfig );
+	const { products, features } = useAppSelector( selectNormalizedReportingConfig );
 	const selectedFeatureProductId = useAppSelector( selectProductIdForFeature( selectedFeatureId ) );
 	const selectedFeatureProductName = selectedFeatureProductId
 		? products[ selectedFeatureProductId ].name
 		: 'Unknown';
+	const selectedFeatureName = selectedFeatureId ? features[ selectedFeatureId ].name : 'Unknown';
 
 	const [ submissionAttempted, setSubmissionAttempted ] = useState( false );
 
@@ -61,6 +62,7 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 
 			monitoringClient.analytics.recordEvent( 'feature_save', {
 				productName: selectedFeatureProductName,
+				featureName: selectedFeatureName,
 			} );
 
 			if ( onContinue ) {

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -2,6 +2,11 @@ import React, { FormEventHandler, ReactNode, useCallback, useEffect, useState } 
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { DebouncedSearch, FormErrorMessage } from '../common/components';
 import { selectIssueFeatureId, setIssueFeatureId } from '../issue-details/issue-details-slice';
+import { useMonitoring } from '../monitoring/monitoring-provider';
+import {
+	selectNormalizedReportingConfig,
+	selectProductIdForFeature,
+} from '../reporting-config/reporting-config-slice';
 import {
 	selectSelectedFeatureId,
 	setFeatureSearchTerm,
@@ -17,6 +22,7 @@ interface Props {
 
 export function FeatureSelectorForm( { onContinue }: Props ) {
 	const dispatch = useAppDispatch();
+	const monitoringClient = useMonitoring();
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 
 	// On mount, we effectively should 'reset' the form state.
@@ -29,6 +35,9 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 
 	const selectedFeatureId = useAppSelector( selectSelectedFeatureId );
 
+	const { products } = useAppSelector( selectNormalizedReportingConfig );
+	const selectedFeatureProductId = useAppSelector( selectProductIdForFeature( selectedFeatureId ) );
+
 	const [ submissionAttempted, setSubmissionAttempted ] = useState( false );
 
 	const readyToContinue = selectedFeatureId !== null;
@@ -36,8 +45,9 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 	const handleSearch = useCallback(
 		( searchTerm: string ) => {
 			dispatch( setFeatureSearchTerm( searchTerm ) );
+			monitoringClient.analytics.recordEvent( 'feature_search', { searchTerm } );
 		},
-		[ dispatch ]
+		[ dispatch, monitoringClient.analytics ]
 	);
 
 	const handleSubmit: FormEventHandler< HTMLFormElement > = ( event ) => {
@@ -45,6 +55,11 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 		setSubmissionAttempted( true );
 		if ( readyToContinue ) {
 			dispatch( setIssueFeatureId( selectedFeatureId ) );
+
+			if ( selectedFeatureProductId ) {
+				const productName = products[ selectedFeatureProductId ].name;
+				monitoringClient.analytics.recordEvent( 'feature_save', { productName } );
+			}
 
 			if ( onContinue ) {
 				onContinue();

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -37,6 +37,9 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 
 	const { products } = useAppSelector( selectNormalizedReportingConfig );
 	const selectedFeatureProductId = useAppSelector( selectProductIdForFeature( selectedFeatureId ) );
+	const selectedFeatureProductName = selectedFeatureProductId
+		? products[ selectedFeatureProductId ].name
+		: 'Unknown';
 
 	const [ submissionAttempted, setSubmissionAttempted ] = useState( false );
 
@@ -56,10 +59,9 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 		if ( readyToContinue ) {
 			dispatch( setIssueFeatureId( selectedFeatureId ) );
 
-			if ( selectedFeatureProductId ) {
-				const productName = products[ selectedFeatureProductId ].name;
-				monitoringClient.analytics.recordEvent( 'feature_save', { productName } );
-			}
+			monitoringClient.analytics.recordEvent( 'feature_save', {
+				productName: selectedFeatureProductName,
+			} );
 
 			if ( onContinue ) {
 				onContinue();

--- a/src/feature-selector-form/sub-components/feature.tsx
+++ b/src/feature-selector-form/sub-components/feature.tsx
@@ -24,10 +24,12 @@ export function Feature( { id }: Props ) {
 	const { features, products } = useAppSelector( selectNormalizedReportingConfig );
 	const productId = useAppSelector( selectProductIdForFeature( id ) );
 	const productName = productId ? products[ productId ].name : 'Unknown';
+	let { name: featureName } = features[ id ];
+	const { keywords, description } = features[ id ];
 
 	const handleFeatureSelect = () => {
 		dispatch( setSelectedFeatureId( id ) );
-		monitoringClient.analytics.recordEvent( 'feature_select', { productName } );
+		monitoringClient.analytics.recordEvent( 'feature_select', { productName, featureName } );
 	};
 
 	const selectedFeatureId = useAppSelector( selectSelectedFeatureId );
@@ -37,16 +39,13 @@ export function Feature( { id }: Props ) {
 		classNames.push( styles.selectedFeature );
 	}
 
-	let { name } = features[ id ];
-	const { keywords, description } = features[ id ];
-
 	const searchTerm = useAppSelector( selectFeatureSearchTerm );
-	if ( searchTerm !== '' && ! includesIgnoringCase( name, searchTerm ) ) {
+	if ( searchTerm !== '' && ! includesIgnoringCase( featureName, searchTerm ) ) {
 		const matchingKeyword = keywords?.find( ( keyword ) =>
 			includesIgnoringCase( keyword, searchTerm )
 		);
 		if ( matchingKeyword ) {
-			name = `${ name } (${ matchingKeyword })`;
+			featureName = `${ featureName } (${ matchingKeyword })`;
 		}
 	}
 
@@ -64,7 +63,7 @@ export function Feature( { id }: Props ) {
 				substring={ searchTerm }
 				highlightClassName={ styles.searchSubstringMatch }
 			>
-				{ name }
+				{ featureName }
 			</SubstringHighlighter>
 		</button>
 	);

--- a/src/feature-selector-form/sub-components/feature.tsx
+++ b/src/feature-selector-form/sub-components/feature.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
-import { selectNormalizedReportingConfig } from '../../reporting-config/reporting-config-slice';
+import {
+	selectNormalizedReportingConfig,
+	selectProductIdForFeature,
+} from '../../reporting-config/reporting-config-slice';
 import styles from './../feature-selector-form.module.css';
 import {
 	selectFeatureSearchTerm,
@@ -18,9 +21,13 @@ interface Props {
 export function Feature( { id }: Props ) {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
+	const { features, products } = useAppSelector( selectNormalizedReportingConfig );
+	const productId = useAppSelector( selectProductIdForFeature( id ) );
+	const productName = productId ? products[ productId ].name : 'Unknown';
+
 	const handleFeatureSelect = () => {
 		dispatch( setSelectedFeatureId( id ) );
-		monitoringClient.analytics.recordEvent( 'feature_select' );
+		monitoringClient.analytics.recordEvent( 'feature_select', { productName } );
 	};
 
 	const selectedFeatureId = useAppSelector( selectSelectedFeatureId );
@@ -30,7 +37,6 @@ export function Feature( { id }: Props ) {
 		classNames.push( styles.selectedFeature );
 	}
 
-	const { features } = useAppSelector( selectNormalizedReportingConfig );
 	let { name } = features[ id ];
 	const { keywords, description } = features[ id ];
 

--- a/src/feature-selector-form/sub-components/feature.tsx
+++ b/src/feature-selector-form/sub-components/feature.tsx
@@ -9,6 +9,7 @@ import {
 } from '../feature-selector-form-slice';
 import { includesIgnoringCase } from '../../common/lib';
 import { SubstringHighlighter } from '../../common/components';
+import { useMonitoring } from '../../monitoring/monitoring-provider';
 
 interface Props {
 	id: string;
@@ -16,7 +17,11 @@ interface Props {
 
 export function Feature( { id }: Props ) {
 	const dispatch = useAppDispatch();
-	const handleFeatureSelect = () => dispatch( setSelectedFeatureId( id ) );
+	const monitoringClient = useMonitoring();
+	const handleFeatureSelect = () => {
+		dispatch( setSelectedFeatureId( id ) );
+		monitoringClient.analytics.recordEvent( 'feature_select' );
+	};
 
 	const selectedFeatureId = useAppSelector( selectSelectedFeatureId );
 	const isSelected = id === selectedFeatureId;

--- a/src/feature-selector-form/sub-components/selected-feature-details.tsx
+++ b/src/feature-selector-form/sub-components/selected-feature-details.tsx
@@ -4,6 +4,7 @@ import { selectNormalizedReportingConfig } from '../../reporting-config/reportin
 import { ReactComponent as ChevronRightIcon } from '../../common/svgs/chevron-right.svg';
 import styles from '../feature-selector-form.module.css';
 import { setSelectedFeatureId } from '../feature-selector-form-slice';
+import { useMonitoring } from '../../monitoring/monitoring-provider';
 
 interface Props {
 	featureId: string;
@@ -11,6 +12,7 @@ interface Props {
 
 export function SelectedFeatureDetails( { featureId }: Props ) {
 	const dispatch = useAppDispatch();
+	const monitoringClient = useMonitoring();
 	const { features, featureGroups, products } = useAppSelector( selectNormalizedReportingConfig );
 	const { name: featureName, description, parentId, parentType } = features[ featureId ];
 
@@ -31,6 +33,7 @@ export function SelectedFeatureDetails( { featureId }: Props ) {
 
 	const handleClearClick = () => {
 		dispatch( setSelectedFeatureId( null ) );
+		monitoringClient.analytics.recordEvent( 'feature_clear' );
 	};
 
 	return (

--- a/src/next-steps/next-steps.tsx
+++ b/src/next-steps/next-steps.tsx
@@ -55,10 +55,11 @@ export function NextSteps() {
 	useEffect( () => {
 		if ( allTasksAreComplete ) {
 			setShowConfetti( true );
+			monitoringClient.analytics.recordEvent( 'task_complete_all' );
 		} else {
 			setShowConfetti( false );
 		}
-	}, [ allTasksAreComplete ] );
+	}, [ allTasksAreComplete, monitoringClient.analytics ] );
 
 	// On mount, we want to calculate the section size for the Confetti
 	// We also want to recalculate whenever the relevant tasks change, or the selected feature

--- a/src/next-steps/next-steps.tsx
+++ b/src/next-steps/next-steps.tsx
@@ -55,7 +55,6 @@ export function NextSteps() {
 	useEffect( () => {
 		if ( allTasksAreComplete ) {
 			setShowConfetti( true );
-			monitoringClient.analytics.recordEvent( 'task_complete_all' );
 		} else {
 			setShowConfetti( false );
 		}

--- a/src/next-steps/sub-components/entity-info.tsx
+++ b/src/next-steps/sub-components/entity-info.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createGeneralHref, createP2Href, createSlackHref } from '../../common/lib';
+import { useMonitoring } from '../../monitoring/monitoring-provider';
 import { Feature, FeatureGroup, LearnMoreLink, Product } from '../../reporting-config/types';
 import styles from '../next-steps.module.css';
 
@@ -8,6 +9,7 @@ interface Props {
 }
 
 export function EntityInfo( { entity }: Props ) {
+	const monitoringClient = useMonitoring();
 	const { name, description, learnMoreLinks } = entity;
 
 	const slackLinks = learnMoreLinks?.filter( ( link ) => link.type === 'slack' );
@@ -17,16 +19,28 @@ export function EntityInfo( { entity }: Props ) {
 	function LinkList( { links }: { links: LearnMoreLink[] } ) {
 		return (
 			<ul>
-				{ links.map( ( link, index ) => (
-					<li
-						className={ styles.moreInfoListItem }
-						key={ `${ entity.id }_${ link.type }_${ index }` }
-					>
-						<a href={ createLinkHref( link ) }>
-							{ link.displayText || getDefaultLinkText( link ) }
-						</a>
-					</li>
-				) ) }
+				{ links.map( ( link, index ) => {
+					const handleClick = () => {
+						monitoringClient.analytics.recordEvent( 'more_info_link_click', {
+							linkType: link.type,
+						} );
+					};
+					return (
+						<li
+							className={ styles.moreInfoListItem }
+							key={ `${ entity.id }_${ link.type }_${ index }` }
+						>
+							<a
+								target="_blank"
+								href={ createLinkHref( link ) }
+								onClick={ handleClick }
+								rel="noreferrer"
+							>
+								{ link.displayText || getDefaultLinkText( link ) }
+							</a>
+						</li>
+					);
+				} ) }
 			</ul>
 		);
 	}

--- a/src/next-steps/sub-components/task.tsx
+++ b/src/next-steps/sub-components/task.tsx
@@ -43,6 +43,7 @@ export function Task( { taskId }: Props ) {
 			dispatch( removeCompletedTask( taskId ) );
 		} else {
 			dispatch( addCompletedTask( taskId ) );
+			monitoringClient.analytics.recordEvent( 'task_complete' );
 		}
 		dispatch( updateHistoryWithState() );
 	};
@@ -57,6 +58,11 @@ export function Task( { taskId }: Props ) {
 	let taskIsBroken = false;
 	let titleDisplay: ReactNode;
 	if ( link ) {
+		const handleLinkClick = () => {
+			monitoringClient.analytics.recordEvent( 'task_link_click', { linkType: link.type } );
+			handleCheckboxChange();
+		};
+
 		try {
 			const linkText = title || getDefaultTitleForLink( link );
 			const href = createLinkHref( link, issueTitle );
@@ -67,7 +73,7 @@ export function Task( { taskId }: Props ) {
 					href={ href }
 					rel="noreferrer"
 					// When they open a link, let's trigger the checkbox change too
-					onClick={ handleCheckboxChange }
+					onClick={ handleLinkClick }
 				>
 					{ getAppIconForLink( link ) }
 					<span className={ styles.linkText }>{ linkText }</span>

--- a/src/next-steps/sub-components/task.tsx
+++ b/src/next-steps/sub-components/task.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectNormalizedReportingConfig } from '../../reporting-config/reporting-config-slice';
 import { TaskLink } from '../../reporting-config/types';
@@ -22,6 +22,7 @@ import {
 import { useMonitoring } from '../../monitoring/monitoring-provider';
 import { updateHistoryWithState } from '../../url-history/actions';
 import { useLoggerWithCache } from '../../monitoring/use-logger-with-cache';
+import { makeSelectorToPredictCompletingAllTasks } from '../../combined-selectors/all-tasks-are-complete';
 
 interface Props {
 	taskId: string;
@@ -38,12 +39,30 @@ export function Task( { taskId }: Props ) {
 
 	const isChecked = completedTaskIds.includes( taskId );
 
+	// If possible, we want to tie all Tracks events to actual user actions like clicks.
+	// This prevents use from making too many misleading events from browser navigations.
+	// This is tricky for calculated state, like all tasks being completed.
+	// But, we can accurately predict if a given task completion will complete all tasks.
+	// But we also need to be careful and make sure there's a unique memoized selector for each task component.
+	// See https://react-redux.js.org/api/hooks#using-memoizing-selectors
+	const selectorToPredictCompletingAllTasks = useMemo(
+		makeSelectorToPredictCompletingAllTasks,
+		[]
+	);
+	const taskCompletionWillCompleteAll = useAppSelector( ( state ) =>
+		selectorToPredictCompletingAllTasks( state, taskId )
+	);
+
 	const handleCheckboxChange = () => {
 		if ( isChecked ) {
 			dispatch( removeCompletedTask( taskId ) );
 		} else {
 			dispatch( addCompletedTask( taskId ) );
 			monitoringClient.analytics.recordEvent( 'task_complete' );
+
+			if ( taskCompletionWillCompleteAll ) {
+				monitoringClient.analytics.recordEvent( 'task_complete_all' );
+			}
 		}
 		dispatch( updateHistoryWithState() );
 	};

--- a/src/reporting-config/reporting-config-slice.ts
+++ b/src/reporting-config/reporting-config-slice.ts
@@ -3,6 +3,7 @@ import { RootState } from '../app/store';
 import { ApiClient, ReportingConfigApiResponse } from '../api/types';
 import { IndexedReportingConfig, NormalizedReportingConfig, ReportingConfigState } from './types';
 import { indexReportingConfig, normalizeReportingConfig } from './reporting-config-parsers';
+import { FeatureId } from '../issue-details/types';
 
 const initialNormalizedReportingConfig: NormalizedReportingConfig = {
 	products: {},
@@ -118,3 +119,19 @@ export const surfaceReportingConfigMiddleware: Middleware< {}, RootState > =
 
 		return next( action );
 	};
+
+export function selectProductIdForFeature( featureId: FeatureId ) {
+	return ( state: RootState ) => {
+		if ( ! featureId ) {
+			return null;
+		}
+
+		const feature = state.reportingConfig.normalized.features[ featureId ];
+		if ( feature.parentType === 'product' ) {
+			return feature.parentId;
+		}
+
+		const featureGroup = state.reportingConfig.normalized.featureGroups[ feature.parentId ];
+		return featureGroup.productId;
+	};
+}

--- a/src/reporting-flow/sub-components/feature-selection-step.tsx
+++ b/src/reporting-flow/sub-components/feature-selection-step.tsx
@@ -7,6 +7,7 @@ import { StepContainer } from './step-container';
 import styles from '../reporting-flow.module.css';
 import { FeatureSelectorForm } from '../../feature-selector-form/feature-selector-form';
 import { updateHistoryWithState } from '../../url-history/actions';
+import { useMonitoring } from '../../monitoring/monitoring-provider';
 
 interface Props {
 	stepNumber: number;
@@ -15,13 +16,15 @@ interface Props {
 
 export function FeatureSelectionStep( { stepNumber, goToNextStep }: Props ) {
 	const dispatch = useAppDispatch();
+	const monitoringClient = useMonitoring();
 	const activeStep = useAppSelector( selectActiveStep );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 
 	const onEdit = useCallback( () => {
 		dispatch( setActiveStep( 'featureSelection' ) );
 		dispatch( updateHistoryWithState() );
-	}, [ dispatch ] );
+		monitoringClient.analytics.recordEvent( 'feature_step_edit' );
+	}, [ dispatch, monitoringClient.analytics ] );
 
 	const isActive = activeStep === 'featureSelection';
 	const isComplete = issueFeatureId !== null && ! isActive;

--- a/src/reporting-flow/sub-components/title-and-type-step.tsx
+++ b/src/reporting-flow/sub-components/title-and-type-step.tsx
@@ -7,6 +7,7 @@ import { selectActiveStep, setActiveStep } from './../active-step-slice';
 import { StepContainer } from './step-container';
 import styles from '../reporting-flow.module.css';
 import { updateHistoryWithState } from '../../url-history/actions';
+import { useMonitoring } from '../../monitoring/monitoring-provider';
 
 interface Props {
 	stepNumber: number;
@@ -15,6 +16,7 @@ interface Props {
 
 export function TitleAndTypeStep( { stepNumber, goToNextStep }: Props ) {
 	const dispatch = useAppDispatch();
+	const monitoringClient = useMonitoring();
 	const activeStep = useAppSelector( selectActiveStep );
 	const issueTitle = useAppSelector( selectIssueTitle );
 	const issueType = useAppSelector( selectIssueType );
@@ -22,7 +24,8 @@ export function TitleAndTypeStep( { stepNumber, goToNextStep }: Props ) {
 	const onEdit = useCallback( () => {
 		dispatch( setActiveStep( 'titleAndType' ) );
 		dispatch( updateHistoryWithState() );
-	}, [ dispatch ] );
+		monitoringClient.analytics.recordEvent( 'type_step_edit' );
+	}, [ dispatch, monitoringClient.analytics ] );
 
 	const isActive = activeStep === 'titleAndType';
 	const isComplete = issueType !== 'unset' && ! isActive;

--- a/src/test-utils/faux-e2e-environment.ts
+++ b/src/test-utils/faux-e2e-environment.ts
@@ -2,10 +2,18 @@ import JsdomEnvironment from 'jest-environment-jsdom';
 import { Circus, Config } from '@jest/types';
 import { EnvironmentContext } from '@jest/environment';
 
-class QuitEarlyEnvironment extends JsdomEnvironment {
+/**
+ * This is a custom Jest environment used for more script-like tests.
+ * Think of E2E tests, but in memory with JSDOM!
+ * The key distinctions:
+ * - We don't reset mocks between tests
+ * - We quit early if a test fails
+ */
+class FauxE2eEnvironment extends JsdomEnvironment {
 	private testHasFailed = false;
 
 	constructor( config: Config.ProjectConfig, context: EnvironmentContext ) {
+		config.resetMocks = false;
 		super( config, context );
 	}
 
@@ -38,4 +46,4 @@ class QuitEarlyEnvironment extends JsdomEnvironment {
 	}
 }
 
-export default QuitEarlyEnvironment;
+export default FauxE2eEnvironment;

--- a/src/title-type-form/title-type-form.tsx
+++ b/src/title-type-form/title-type-form.tsx
@@ -15,6 +15,7 @@ import {
 import { IssueType } from '../issue-details/types';
 import { ReactComponent as InfoIcon } from '../common/svgs/info.svg';
 import styles from './title-type-form.module.css';
+import { useMonitoring } from '../monitoring/monitoring-provider';
 
 interface Props {
 	onContinue?: () => void;
@@ -22,6 +23,7 @@ interface Props {
 
 export function TitleTypeForm( { onContinue }: Props ) {
 	const dispatch = useAppDispatch();
+	const monitoringClient = useMonitoring();
 	const { issueTitle, issueType } = useAppSelector( selectIssueDetails );
 
 	const [ title, setTitle ] = useState( issueTitle );
@@ -59,6 +61,11 @@ export function TitleTypeForm( { onContinue }: Props ) {
 		if ( readyToContinue ) {
 			dispatch( setIssueTitle( title ) );
 			dispatch( setIssueType( type ) );
+
+			monitoringClient.analytics.recordEvent( 'type_save', { issueType: type } );
+			if ( title ) {
+				monitoringClient.analytics.recordEvent( 'title_save' );
+			}
 
 			if ( onContinue ) {
 				onContinue();

--- a/src/url-history/__tests__/history-updates.test.tsx
+++ b/src/url-history/__tests__/history-updates.test.tsx
@@ -1,5 +1,5 @@
 /**
- * @jest-environment ./src/test-utils/quit-early-environment.ts
+ * @jest-environment ./src/test-utils/faux-e2e-environment.ts
  */
 
 import '@testing-library/react/dont-cleanup-after-each';


### PR DESCRIPTION
#### What Does This PR Add/Change?

Adds the actual triggering of the remaining Tracks events on the client!

See this P2 for the full list of events: pciE2j-1LC-p2

** One unique note worth mentioning: Apart from page load, I've tried to tie every event to a direct user action (like actually clicking on the page). This means that loading a URL with existing state or using browser back/forward will _not_ trigger track events. I think this will get us a much more accurate picture of how users are using the app! Otherwise, we could get a lot of event spam in confusing orders.

#### Testing Instructions

You can see the full list of events here: pciE2j-1LC-p2

I have...
1. Gone through the app flow locally and verified all events in the console
2. Added unit tests for all events

You can verify in the console as well!

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #
