### PR TITLE
Add a start over button

### DIFF
--- a/src/feature-selector-form/feature-selector-form-slice.ts
+++ b/src/feature-selector-form/feature-selector-form-slice.ts
@@ -25,6 +25,13 @@ export const featureSelectorFormSlice = createSlice( {
 			};
 		},
 	},
+	extraReducers: ( builder ) => {
+		builder.addCase( 'startOver', () => {
+			return {
+				...initialState,
+			};
+		} );
+	},
 } );
 
 export const featureSelectorFormReducer = featureSelectorFormSlice.reducer;

--- a/src/issue-details/issue-details-slice.ts
+++ b/src/issue-details/issue-details-slice.ts
@@ -36,37 +36,43 @@ export const issueDetailsSlice = createSlice( {
 		},
 	},
 	extraReducers: ( builder ) => {
-		builder.addCase( updateStateFromHistory, ( state, action ) => {
-			const issueDetails = action.payload.issueDetails;
-			if ( ! issueDetails || typeof issueDetails !== 'object' ) {
-				return { ...initialState };
-			}
+		builder
+			.addCase( updateStateFromHistory, ( state, action ) => {
+				const issueDetails = action.payload.issueDetails;
+				if ( ! issueDetails || typeof issueDetails !== 'object' ) {
+					return { ...initialState };
+				}
 
-			// Validate the payload from history, and fall back to the initial state if invalid.
+				// Validate the payload from history, and fall back to the initial state if invalid.
 
-			const issueType = validIssueTypes.has( issueDetails.issueType )
-				? issueDetails.issueType
-				: initialState.issueType;
+				const issueType = validIssueTypes.has( issueDetails.issueType )
+					? issueDetails.issueType
+					: initialState.issueType;
 
-			const issueTitle = issueDetails.issueTitle ?? initialState.issueTitle;
+				const issueTitle = issueDetails.issueTitle ?? initialState.issueTitle;
 
-			const actionWithReportingConfig = action as PayloadAction<
-				FeatureId,
-				string,
-				NormalizedReportingConfig
-			>;
-			const { features } = actionWithReportingConfig.meta;
-			let featureId: FeatureId;
-			if ( issueDetails.featureId === null || features[ issueDetails.featureId ] ) {
-				featureId = issueDetails.featureId;
-			} else {
-				// This may seem silly because the initial state is currently null
-				// but it future proofs in we change the initial state.
-				featureId = initialState.featureId;
-			}
+				const actionWithReportingConfig = action as PayloadAction<
+					FeatureId,
+					string,
+					NormalizedReportingConfig
+				>;
+				const { features } = actionWithReportingConfig.meta;
+				let featureId: FeatureId;
+				if ( issueDetails.featureId === null || features[ issueDetails.featureId ] ) {
+					featureId = issueDetails.featureId;
+				} else {
+					// This may seem silly because the initial state is currently null
+					// but it future proofs in we change the initial state.
+					featureId = initialState.featureId;
+				}
 
-			return { featureId, issueType, issueTitle };
-		} );
+				return { featureId, issueType, issueTitle };
+			} )
+			.addCase( 'startOver', () => {
+				return {
+					...initialState,
+				};
+			} );
 	},
 } );
 

--- a/src/monitoring/types.ts
+++ b/src/monitoring/types.ts
@@ -39,7 +39,8 @@ export type EventName =
 	| 'task_complete'
 	| 'task_complete_all'
 	| 'task_link_click'
-	| 'more_info_link_click';
+	| 'more_info_link_click'
+	| 'start_over_click';
 
 export interface LogPayload {
 	feature: 'bugomattic_client';

--- a/src/next-steps/completed-tasks-slice.ts
+++ b/src/next-steps/completed-tasks-slice.ts
@@ -30,24 +30,28 @@ export const completedTasksSlice = createSlice( {
 		},
 	},
 	extraReducers: ( builder ) => {
-		builder.addCase( updateStateFromHistory, ( state, action ) => {
-			const completedTasks = action.payload.completedTasks;
-			if ( ! completedTasks ) {
+		builder
+			.addCase( updateStateFromHistory, ( state, action ) => {
+				const completedTasks = action.payload.completedTasks;
+				if ( ! completedTasks ) {
+					return [ ...initialState ];
+				}
+
+				const actionWithReportingConfig = action as PayloadAction<
+					TaskId,
+					string,
+					NormalizedReportingConfig
+				>;
+				const { tasks } = actionWithReportingConfig.meta;
+
+				const filteredCompletedTasks = completedTasks.filter(
+					( taskId ) => typeof taskId === 'string' && !! tasks[ taskId ]
+				);
+				return [ ...filteredCompletedTasks ];
+			} )
+			.addCase( 'startOver', () => {
 				return [ ...initialState ];
-			}
-
-			const actionWithReportingConfig = action as PayloadAction<
-				TaskId,
-				string,
-				NormalizedReportingConfig
-			>;
-			const { tasks } = actionWithReportingConfig.meta;
-
-			const filteredCompletedTasks = completedTasks.filter(
-				( taskId ) => typeof taskId === 'string' && !! tasks[ taskId ]
-			);
-			return [ ...filteredCompletedTasks ];
-		} );
+			} );
 	},
 } );
 

--- a/src/next-steps/next-steps.module.css
+++ b/src/next-steps/next-steps.module.css
@@ -82,6 +82,12 @@ a.taskTitle:hover {
 	margin: 0.5rem 0 0 0;
 }
 
+.startOverButtonWrapper {
+	display: flex;
+	justify-content: end;
+	margin-top: 1.5rem;
+}
+
 .moreInfoSection {
 	margin-top: 2rem;
 	border-top: 1px solid var( --color-border );

--- a/src/next-steps/next-steps.module.css
+++ b/src/next-steps/next-steps.module.css
@@ -85,11 +85,10 @@ a.taskTitle:hover {
 .startOverButtonWrapper {
 	display: flex;
 	justify-content: end;
-	margin-top: 1.5rem;
 }
 
 .moreInfoSection {
-	margin-top: 2rem;
+	margin-top: 1.5rem;
 	border-top: 1px solid var( --color-border );
 }
 

--- a/src/next-steps/next-steps.tsx
+++ b/src/next-steps/next-steps.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useAppSelector } from '../app/hooks';
+import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { selectRelevantTaskIds } from '../combined-selectors/relevant-task-ids';
 import { Task } from './sub-components/task';
 import styles from './next-steps.module.css';
@@ -9,8 +9,11 @@ import { selectIssueFeatureId } from '../issue-details/issue-details-slice';
 import { selectAllTasksAreComplete } from '../combined-selectors/all-tasks-are-complete';
 import { useMonitoring } from '../monitoring/monitoring-provider';
 import { selectNormalizedReportingConfig } from '../reporting-config/reporting-config-slice';
+import { startOver } from './start-over-action';
+import { updateHistoryWithState } from '../url-history/actions';
 
 export function NextSteps() {
+	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
 
 	const sectionRef = useRef< HTMLElement >( null );
@@ -22,6 +25,12 @@ export function NextSteps() {
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 	const relevantTaskIds = useAppSelector( selectRelevantTaskIds );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
+
+	const handleStartOverClick = () => {
+		dispatch( startOver() );
+		dispatch( updateHistoryWithState() );
+		monitoringClient.analytics.recordEvent( 'start_over_click' );
+	};
 
 	useEffect( () => {
 		const sourcesInOrder = relevantTaskIds.map( ( taskId ) => {
@@ -97,6 +106,11 @@ export function NextSteps() {
 					<Task key={ taskId } taskId={ taskId } />
 				) ) }
 			</ol>
+			<div className={ styles.startOverButtonWrapper }>
+				<button className="primaryButton" onClick={ handleStartOverClick }>
+					Start Over
+				</button>
+			</div>
 			<MoreInfo />
 		</section>
 	);

--- a/src/next-steps/start-over-action.ts
+++ b/src/next-steps/start-over-action.ts
@@ -1,0 +1,3 @@
+import { createAction } from '@reduxjs/toolkit';
+
+export const startOver = createAction< void >( 'startOver' );

--- a/src/reporting-flow/__tests__/reporting-flow.test.tsx
+++ b/src/reporting-flow/__tests__/reporting-flow.test.tsx
@@ -214,7 +214,7 @@ describe( '[Reporting Flow]', () => {
 		).toBeInTheDocument();
 	} );
 
-	test( 'The feature selection form is replaced with details about issue title and type', async () => {
+	test( 'The type and title form is replaced with details about issue title and type', async () => {
 		expect(
 			screen.queryByRole( 'form', { name: 'Set issue type and title' } )
 		).not.toBeInTheDocument();
@@ -418,5 +418,29 @@ describe( '[Reporting Flow]', () => {
 		expect(
 			screen.queryByRole( 'form', { name: 'Set issue type and title' } )
 		).not.toBeInTheDocument();
+	} );
+
+	test( 'Click the Start Over button', async () => {
+		await user.click( screen.getByRole( 'button', { name: 'Start Over' } ) );
+	} );
+
+	test( 'Everything resets to its initial state', async () => {
+		// First step is expanded
+		expect( screen.getByRole( 'form', { name: 'Select a feature' } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'form', { name: 'Set issue title and type' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'list', { name: 'Steps to report issue' } )
+		).not.toBeInTheDocument();
+
+		// No feature is selected
+		expect(
+			screen.queryByRole( 'button', { name: 'Clear currently selected feature' } )
+		).not.toBeInTheDocument();
+
+		// No saved type and title visible
+		expect( screen.queryByText( 'Feature Request' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( issueTitle ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/src/reporting-flow/active-step-slice.ts
+++ b/src/reporting-flow/active-step-slice.ts
@@ -16,18 +16,20 @@ export const featureSelectorFormSlice = createSlice( {
 		},
 	},
 	extraReducers: ( builder ) => {
-		builder.addCase( updateStateFromHistory, ( state, action ) => {
-			const activeStep = action.payload.activeStep;
-			if ( ! activeStep ) {
-				return initialState;
-			}
+		builder
+			.addCase( updateStateFromHistory, ( state, action ) => {
+				const activeStep = action.payload.activeStep;
+				if ( ! activeStep ) {
+					return initialState;
+				}
 
-			if ( ! validActiveSteps.has( activeStep ) ) {
-				return initialState;
-			}
+				if ( ! validActiveSteps.has( activeStep ) ) {
+					return initialState;
+				}
 
-			return action.payload.activeStep;
-		} );
+				return action.payload.activeStep;
+			} )
+			.addCase( 'startOver', () => initialState );
 	},
 } );
 

--- a/src/reporting-flow/reporting-flow.module.css
+++ b/src/reporting-flow/reporting-flow.module.css
@@ -59,7 +59,7 @@
 }
 
 .stepContent {
-	padding: 1rem 1.5rem;
+	padding: 1.25rem 1.5rem;
 	background-color: var( --color-shaded-background );
 	border-radius: 0 0 4px 4px;
 	position: relative;

--- a/src/url-history/__tests__/history-updates.test.tsx
+++ b/src/url-history/__tests__/history-updates.test.tsx
@@ -59,6 +59,7 @@ describe( 'history updates', () => {
 		'onFirstTaskUnComplete',
 		'onFeatureSelectionEdit',
 		'onTypeTitleEdit',
+		'onStartOver',
 	] as const;
 
 	type PointInTime = typeof pointsInTime[ number ];
@@ -162,6 +163,20 @@ describe( 'history updates', () => {
 
 			expect( screen.getByRole( 'list', { name: 'Steps to report issue' } ) ).toBeInTheDocument();
 		},
+
+		onStartOver: () => {
+			expect( screen.getByRole( 'form', { name: 'Select a feature' } ) ).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: 'Clear currently selected feature' } )
+			).not.toBeInTheDocument();
+
+			expect(
+				screen.queryByRole( 'form', { name: 'Set issue title and type' } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'list', { name: 'Steps to report issue' } )
+			).not.toBeInTheDocument();
+		},
 	};
 
 	const referenceUrlQueries: { [ key in PointInTime ]: string } = {
@@ -172,6 +187,7 @@ describe( 'history updates', () => {
 		onFirstTaskUnComplete: 'WILL BE SET IN TEST',
 		onFeatureSelectionEdit: 'WILL BE SET IN TEST',
 		onTypeTitleEdit: 'WILL BE SET IN TEST',
+		onStartOver: 'WILL BE SET IN TEST',
 	};
 
 	let user: UserEvent;
@@ -269,6 +285,15 @@ describe( 'history updates', () => {
 			expect( referenceUrlQueries.onTypeTitleEdit ).not.toBe(
 				referenceUrlQueries.onFeatureSelectionEdit
 			);
+		} );
+
+		test( 'onStartOver', async () => {
+			await user.click( screen.getByRole( 'button', { name: 'Start Over' } ) );
+
+			validations.onStartOver();
+
+			referenceUrlQueries.onStartOver = history.location.search;
+			expect( referenceUrlQueries.onStartOver ).not.toBe( referenceUrlQueries.onTypeTitleEdit );
 		} );
 	} );
 


### PR DESCRIPTION
#### What Does This PR Add/Change?

Adds a start over button at the end of the flow! 🎉 

I also added a Tracks event for this button under the name `start_over_click`

#### Testing Instructions

Click the button! The flow should effectively reset. You'll also see a track event in the console.

(You may notice that we don't explicitly clear the URL all the way back to `/`. This is actually intentional for now! I want to keep the ideas of "starting over" vs re-navigating to the root URL distinct for now. In the future, there may be state we want to preserve even when starting over, like not switching back to duplicate searching, e.g. )

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #