### PR TITLE
Fix prod client implementations class binding

### DIFF
--- a/src/api/__tests__/production-api-client.test.ts
+++ b/src/api/__tests__/production-api-client.test.ts
@@ -1,4 +1,4 @@
-import { ProductionApiClient } from '../production-api-client';
+import { createProductionApiClient } from '../production-api-client';
 import { createServer, Request, Response } from 'miragejs';
 import { ReportingConfigApiResponse } from '../types';
 import { LogPayload } from '../../monitoring/types';
@@ -45,7 +45,7 @@ describe( '[ProductionApiClient]', () => {
 
 	describe( 'loadReportingConfig()', () => {
 		test( 'Calls the correct endpoint and returns the reporting config', async () => {
-			const apiClient = new ProductionApiClient();
+			const apiClient = createProductionApiClient();
 			const reportingConfig = await apiClient.loadReportingConfig();
 
 			// If this returns correctly, we called the correct endpoint.
@@ -53,7 +53,7 @@ describe( '[ProductionApiClient]', () => {
 		} );
 
 		test( 'The request includes the nonce in the right header', async () => {
-			const apiClient = new ProductionApiClient();
+			const apiClient = createProductionApiClient();
 			await apiClient.loadReportingConfig();
 
 			// The types are borked here, see: https://github.com/pretenderjs/pretender/pull/353
@@ -63,7 +63,7 @@ describe( '[ProductionApiClient]', () => {
 		} );
 
 		test( 'Throws an error if the request fails', async () => {
-			const apiClient = new ProductionApiClient();
+			const apiClient = createProductionApiClient();
 
 			const errorBody = {
 				error: 'Something went wrong',
@@ -89,12 +89,12 @@ describe( '[ProductionApiClient]', () => {
 		};
 
 		test( 'Calls the correct endpoint', async () => {
-			const apiClient = new ProductionApiClient();
+			const apiClient = createProductionApiClient();
 			await expect( apiClient.log( fakeLogPayload ) ).resolves.not.toThrowError();
 		} );
 
 		test( 'The request includes the nonce in the right header', async () => {
-			const apiClient = new ProductionApiClient();
+			const apiClient = createProductionApiClient();
 			await apiClient.log( fakeLogPayload );
 
 			// The types are borked here, see: https://github.com/pretenderjs/pretender/pull/353
@@ -104,7 +104,7 @@ describe( '[ProductionApiClient]', () => {
 		} );
 
 		test( 'The request includes the log payload in the body', async () => {
-			const apiClient = new ProductionApiClient();
+			const apiClient = createProductionApiClient();
 			await apiClient.log( fakeLogPayload );
 
 			// The types are borked here, see: https://github.com/pretenderjs/pretender/pull/353
@@ -114,7 +114,7 @@ describe( '[ProductionApiClient]', () => {
 		} );
 
 		test( 'Throws an error if the request fails', async () => {
-			const apiClient = new ProductionApiClient();
+			const apiClient = createProductionApiClient();
 
 			const errorBody = {
 				error: 'Invalid request',

--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -1,7 +1,7 @@
 import { LoggerApiClient, LogPayload } from '../monitoring/types';
 import { ApiClient, ReportingConfigApiResponse } from './types';
 
-export class ProductionApiClient implements ApiClient, LoggerApiClient {
+class ProductionApiClient implements ApiClient, LoggerApiClient {
 	private nonce: string;
 	private nonceHeaderName: string;
 
@@ -51,4 +51,12 @@ export class ProductionApiClient implements ApiClient, LoggerApiClient {
 			);
 		}
 	}
+}
+
+export function createProductionApiClient(): ApiClient & LoggerApiClient {
+	const productionApiClient = new ProductionApiClient();
+	return {
+		loadReportingConfig: productionApiClient.loadReportingConfig.bind( productionApiClient ),
+		log: productionApiClient.log.bind( productionApiClient ),
+	};
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { App } from './app/app';
 import { localMonitoringClient } from './monitoring/local-monitoring-client';
 import { localApiClient } from './api/local-api-client';
 import { MonitoringProvider } from './monitoring/monitoring-provider';
-import { ProductionApiClient } from './api/production-api-client';
+import { createProductionApiClient } from './api/production-api-client';
 import { MonitoringClient } from './monitoring/types';
 import { ApiClient } from './api/types';
 import { createProductionMonitoringClient } from './monitoring/production-monitoring-client';
@@ -16,7 +16,7 @@ let apiClient: ApiClient;
 let monitoringClient: MonitoringClient;
 
 if ( isProduction() ) {
-	const productionApiClient = new ProductionApiClient();
+	const productionApiClient = createProductionApiClient();
 	apiClient = productionApiClient;
 	monitoringClient = createProductionMonitoringClient( productionApiClient );
 } else {

--- a/src/monitoring/production-monitoring-client.ts
+++ b/src/monitoring/production-monitoring-client.ts
@@ -76,8 +76,16 @@ class ProductionAnalyticsClient implements AnalyticsClient {
 export function createProductionMonitoringClient(
 	loggerApiClient: LoggerApiClient
 ): MonitoringClient {
+	const productionLoggerClient = new ProducutionLoggerClient( loggerApiClient );
+	const productionAnalyticsClient = new ProductionAnalyticsClient();
 	return {
-		logger: new ProducutionLoggerClient( loggerApiClient ),
-		analytics: new ProductionAnalyticsClient(),
+		logger: {
+			debug: productionLoggerClient.debug.bind( productionLoggerClient ),
+			info: productionLoggerClient.info.bind( productionLoggerClient ),
+			error: productionLoggerClient.error.bind( productionLoggerClient ),
+		},
+		analytics: {
+			recordEvent: productionAnalyticsClient.recordEvent.bind( productionAnalyticsClient ),
+		},
 	};
 }


### PR DESCRIPTION
#### What Does This PR Add/Change?

`this` strikes again! 🤦 

Our prod clients (API and monitoring) use classes for their implementation. However, exposing the classes directly is risky because of `this` binding. In the current implementation, it was possible to trigger errors if you passed around some of the logging functions, because `this` is undefined.

To fix this, we just re-expose the public functions of the class correctly bound to the class. This makes them safe to use and pass around anywhere!

#### Testing Instructions

Testing this manually is a bit involved as you need to combine a backend patch on a sandbox with this deploy -- I've already done and taken care of that!

All the unit tests should still pass (and they do!)

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #