### PR TITLE
Add reporting config cache

### DIFF
--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -29,7 +29,7 @@ class ProductionApiClient implements ApiClient, LoggerApiClient {
 		if ( response.ok ) {
 			const data = await response.json();
 
-			const cacheExpiryTime = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
+			const cacheExpiryTime = Date.now() + 3 * 24 * 60 * 60 * 1000; // 3 days in milliseconds
 			localStorage.setItem( 'cachedReportingConfigData', JSON.stringify( data ) );
 			localStorage.setItem( 'cacheExpiry', cacheExpiryTime.toString() );
 


### PR DESCRIPTION
#### What Does This PR Add/Change?

This PR adds a cache for the reporting config data in the `production-api-client` module. The cache will store the data for 7 days, and if the data is requested within this period, it will be retrieved from the cache instead of the API.

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

*

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #