### PR TITLE
Add API client implementations for duplicate searching

### DIFF
--- a/src/api/__tests__/production-api-client.test.ts
+++ b/src/api/__tests__/production-api-client.test.ts
@@ -1,6 +1,6 @@
 import { createProductionApiClient } from '../production-api-client';
 import { createServer, Request, Response } from 'miragejs';
-import { IssueApiResponse, ReportingConfigApiResponse } from '../types';
+import { Issue, ReportingConfigApiResponse } from '../types';
 import { LogPayload } from '../../monitoring/types';
 import { Server } from 'pretender';
 
@@ -20,7 +20,7 @@ describe( '[ProductionApiClient]', () => {
 		},
 	};
 
-	const fakeIssues: IssueApiResponse = [
+	const fakeIssues: Issue[] = [
 		{
 			author: 'Test author',
 			content: 'Test content',

--- a/src/api/local-api-client.ts
+++ b/src/api/local-api-client.ts
@@ -1,4 +1,4 @@
-import { ApiClient } from './types';
+import { ApiClient, Issue } from './types';
 import path from 'path-browserify';
 
 /**
@@ -6,11 +6,6 @@ import path from 'path-browserify';
  */
 export const localApiClient: ApiClient = {
 	loadReportingConfig: async () => {
-		const wait = ( ms: number ) =>
-			new Promise( ( resolve ) => {
-				setTimeout( resolve, ms );
-			} );
-
 		// Let's keep us honest by adding a little delay here.
 		await wait( 2000 );
 
@@ -30,4 +25,74 @@ export const localApiClient: ApiClient = {
 			);
 		}
 	},
+
+	searchIssues: async ( search, options ) => {
+		// Delay to simulate network latency.
+		await wait( 2000 );
+
+		// We can tweak this as needed during testing!
+		// As a baseline, we'll show all the passed search parameters in the content.
+		// And we'll randomize some other stuff so there's good variability.
+
+		const numberOfIssues = Math.floor( Math.random() * 20 );
+		const issues: Issue[] = [];
+		for ( let i = 0; i < numberOfIssues; i++ ) {
+			const randomString = Math.random().toString( 16 ).slice( 2 );
+			const title = `Issue ${ randomString }`;
+
+			const providedRepos = ( options?.repos || [ 'none provided' ] ).join( ', ' );
+			const providedStatus = options?.status || 'none provided';
+			const providedSort = options?.sort || 'none provided';
+			const content = `Search: <em data-search-match>${ search }</em> | Repos: ${ providedRepos } | Status: ${ providedStatus } | Sort: ${ providedSort }`;
+
+			const status = Math.random() > 0.5 ? 'open' : 'closed';
+
+			const oneWeekInMilliseconds = 7 * 24 * 60 * 60 * 1000;
+			const randomDate = new Date(
+				Date.now() - Math.floor( Math.random() * oneWeekInMilliseconds )
+			).toISOString();
+
+			issues.push( {
+				dateCreated: randomDate,
+				dateUpdated: randomDate,
+				title,
+				content,
+				status,
+				author: 'Fake Author',
+				repo: 'Fakeorg/fake-repo',
+				url: `https://github.com/Automattic/wp-calypso/issues/${ i }`,
+			} );
+		}
+
+		return issues;
+	},
+
+	getRepoFilters: async () => {
+		await wait( 2000 );
+		return [
+			'Automattic/wp-calypso',
+			'Automattic/wp-desktop',
+			'Automattic/jetpack',
+			'Automattic/themes',
+			'Automattic/simplenote-ios',
+			'Automattic/simplenote-android',
+			'Automattic/pocket-casts-ios',
+			'Automattic/sensei',
+			'Automattic/woocommerce.com',
+			'Automattic/newspack-blocks',
+			'wordpress-mobile/WordPress-iOS',
+			'wordpress-mobile/WordPress-Android',
+			'woocommerce/woocommerce',
+			'woocommerce/woocommerce-blocks',
+			'woocommerce/woocommerce-admin',
+			'woocommerce/woocommerce-ios',
+			'woocommerce/woocommerce-android',
+		];
+	},
 };
+
+async function wait( ms: number ) {
+	return new Promise( ( resolve ) => {
+		setTimeout( resolve, ms );
+	} );
+}

--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -1,10 +1,5 @@
 import { LoggerApiClient, LogPayload } from '../monitoring/types';
-import {
-	ApiClient,
-	IssueApiResponse,
-	ReportingConfigApiResponse,
-	SearchIssueOptions,
-} from './types';
+import { ApiClient, Issue, ReportingConfigApiResponse, SearchIssueOptions } from './types';
 
 class ProductionApiClient implements ApiClient, LoggerApiClient {
 	private nonce: string;
@@ -90,7 +85,7 @@ class ProductionApiClient implements ApiClient, LoggerApiClient {
 		}
 	}
 
-	async searchIssues( search: string, options?: SearchIssueOptions ): Promise< IssueApiResponse > {
+	async searchIssues( search: string, options?: SearchIssueOptions ): Promise< Issue[] > {
 		const queryParams = new URLSearchParams();
 		queryParams.set( 'search', search );
 		if ( options?.sort ) {

--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -1,5 +1,10 @@
 import { LoggerApiClient, LogPayload } from '../monitoring/types';
-import { ApiClient, ReportingConfigApiResponse } from './types';
+import {
+	ApiClient,
+	IssueApiResponse,
+	ReportingConfigApiResponse,
+	SearchIssueOptions,
+} from './types';
 
 class ProductionApiClient implements ApiClient, LoggerApiClient {
 	private nonce: string;
@@ -63,6 +68,62 @@ class ProductionApiClient implements ApiClient, LoggerApiClient {
 			);
 		}
 	}
+
+	async getRepoFilters(): Promise< string[] > {
+		const request = new Request( '/wp-json/bugomattic/v1/repos/', {
+			method: 'GET',
+			credentials: 'same-origin',
+			headers: new Headers( {
+				[ this.nonceHeaderName ]: this.nonce,
+			} ),
+		} );
+		const response = await fetch( request );
+
+		if ( response.ok ) {
+			return response.json();
+		} else {
+			throw new Error(
+				`Get Repo Filters web request failed with status code ${
+					response.status
+				}. Response body: ${ JSON.stringify( await response.json() ) }`
+			);
+		}
+	}
+
+	async searchIssues( search: string, options?: SearchIssueOptions ): Promise< IssueApiResponse > {
+		const queryParams = new URLSearchParams();
+		queryParams.set( 'search', search );
+		if ( options?.sort ) {
+			queryParams.set( 'sort', options.sort );
+		}
+		if ( options?.status ) {
+			queryParams.set( 'status', options.status );
+		}
+		if ( options?.repos ) {
+			for ( const repo of options.repos ) {
+				queryParams.append( 'repos[]', repo );
+			}
+		}
+
+		const request = new Request( `/wp-json/bugomattic/v1/issues/?${ queryParams.toString() }`, {
+			method: 'GET',
+			credentials: 'same-origin',
+			headers: new Headers( {
+				[ this.nonceHeaderName ]: this.nonce,
+			} ),
+		} );
+		const response = await fetch( request );
+
+		if ( response.ok ) {
+			return response.json();
+		} else {
+			throw new Error(
+				`Search Issues web request failed with status code ${
+					response.status
+				}. Response body: ${ JSON.stringify( await response.json() ) }`
+			);
+		}
+	}
 }
 
 export function createProductionApiClient(): ApiClient & LoggerApiClient {
@@ -70,5 +131,7 @@ export function createProductionApiClient(): ApiClient & LoggerApiClient {
 	return {
 		loadReportingConfig: productionApiClient.loadReportingConfig.bind( productionApiClient ),
 		log: productionApiClient.log.bind( productionApiClient ),
+		getRepoFilters: productionApiClient.getRepoFilters.bind( productionApiClient ),
+		searchIssues: productionApiClient.searchIssues.bind( productionApiClient ),
 	};
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,10 +6,9 @@ import { LearnMoreLink, TaskDetails } from '../reporting-config/types';
  */
 export interface ApiClient {
 	loadReportingConfig(): Promise< ReportingConfigApiResponse >;
-	searchIssues( search: string, options?: SearchIssueOptions ): Promise< IssueApiResponse >;
+	searchIssues( search: string, options?: SearchIssueOptions ): Promise< Issue[] >;
 	getRepoFilters(): Promise< string[] >;
 	// More to come as we add to the API
-	// e.g. searchForDuplicats();
 	// e.g. saveNewReportingConfig();
 }
 
@@ -56,8 +55,6 @@ export interface ApiTasks {
 	featureRequest: TaskDetails[];
 	urgent: TaskDetails[];
 }
-
-export type IssueApiResponse = Issue[];
 
 export interface Issue {
 	dateCreated: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,6 +6,8 @@ import { LearnMoreLink, TaskDetails } from '../reporting-config/types';
  */
 export interface ApiClient {
 	loadReportingConfig(): Promise< ReportingConfigApiResponse >;
+	searchIssues( search: string, options?: SearchIssueOptions ): Promise< IssueApiResponse >;
+	getRepoFilters(): Promise< string[] >;
 	// More to come as we add to the API
 	// e.g. searchForDuplicats();
 	// e.g. saveNewReportingConfig();
@@ -53,4 +55,23 @@ export interface ApiTasks {
 	bug: TaskDetails[];
 	featureRequest: TaskDetails[];
 	urgent: TaskDetails[];
+}
+
+export type IssueApiResponse = Issue[];
+
+export interface Issue {
+	dateCreated: string;
+	dateUpdated: string;
+	title: string;
+	url: string;
+	repo: string;
+	status: 'open' | 'closed';
+	author: string;
+	content: string;
+}
+
+export interface SearchIssueOptions {
+	repos?: string[];
+	status?: 'open' | 'closed' | 'all';
+	sort?: 'date-created' | 'relevance';
 }

--- a/src/test-utils/mock-api-client.ts
+++ b/src/test-utils/mock-api-client.ts
@@ -3,5 +3,7 @@ export function createMockApiClient() {
 		loadReportingConfig: jest.fn( async () => {
 			return {};
 		} ),
+		searchIssues: jest.fn( async () => [] ),
+		getRepoFilters: jest.fn( async () => [] ),
 	};
 }


### PR DESCRIPTION
#### What Does This PR Add/Change?

Matching the backend changes here: D105829-code

This adds API client implementations for the two endpoints needed for duplicate searching:
- `searchIssues` - `GET /issues`
- `getRepoFilters` - `GET /repos`

#### Testing Instructions

Hard to test right now manually, as we'll need to build components to use these calls.

But for now, I've added full unit test coverage of the web requests 👍 

#### Issues

Related to #  
Closes #