### PR TITLE
Add keywords to selected feature

### DIFF
--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -4,3 +4,4 @@ export * from './limited-text-field';
 export * from './form-error-message';
 export * from './animated-ellipsis';
 export * from './loading-indicator';
+export * from './pill';

--- a/src/common/components/pill.module.css
+++ b/src/common/components/pill.module.css
@@ -1,0 +1,12 @@
+@import '../../variables.css';
+
+.pill {
+	background-color: var( --color-primary-light );
+	font-size: var( --font-body-small );
+	color: var( --color-text-light );
+	font-weight: 400;
+	display: inline-block;
+	padding: 0.34375rem 0.625rem;
+	margin: 0 0.5rem 0.5rem 0;
+	border-radius: 61px;
+}

--- a/src/common/components/pill.module.css
+++ b/src/common/components/pill.module.css
@@ -7,6 +7,6 @@
 	font-weight: 400;
 	display: inline-block;
 	padding: 0.34375rem 0.625rem;
-	margin: 0 0.5rem 0.5rem 0;
+	margin: 0.5rem 0.5rem 0 0;
 	border-radius: 61px;
 }

--- a/src/common/components/pill.tsx
+++ b/src/common/components/pill.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './pill.module.css';
+
+interface Props {
+	keyword: string;
+}
+
+export function Pill( { keyword }: Props ) {
+	return (
+		<span role="listitem" className={ styles.pill }>
+			{ keyword }
+		</span>
+	);
+}

--- a/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-selection.test.tsx
@@ -20,6 +20,7 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 		description: 'Test Feature Under Group Description',
 		parentType: 'featureGroup',
 		parentId: 'feature_group',
+		keywords: [ 'ABC keyword' ],
 	};
 
 	const featureUnderProduct: Feature = {
@@ -145,18 +146,11 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			featureUnderGroup.description!
 		);
-		// Breadcrumb
-		expect(
-			screen.getByText( ( content ) => {
-				// This is kinda gross, but matching the text node of the breadcrumb exactly is a bit wonky -- this is more stable.
-				return (
-					content.includes( product.name ) &&
-					content.includes( featureGroup.name ) &&
-					content.includes( featureUnderGroup.name ) &&
-					content.indexOf( product.name ) < content.indexOf( featureGroup.name ) &&
-					content.indexOf( featureGroup.name ) < content.indexOf( featureUnderGroup.name )
-				);
-			} )
+
+		// Keywords
+		expect( screen.getByTestId( 'selected-feature-keywords' ) ).toHaveTextContent(
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			featureUnderGroup.keywords![ 0 ]
 		);
 
 		await user.click(
@@ -178,17 +172,15 @@ describe( '[FeatureSelector -- Feature Selection]', () => {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			featureUnderProduct.description!
 		);
-		// Breadcrumb
-		expect(
-			screen.getByText( ( content ) => {
-				// This is kinda gross, but matching the text node of the breadcrumb exactly is a bit wonky -- this is more stable.
-				return (
-					content.includes( product.name ) &&
-					content.includes( featureUnderProduct.name ) &&
-					content.indexOf( product.name ) < content.indexOf( featureUnderProduct.name )
-				);
-			} )
-		);
+		// Keywords
+		if ( featureUnderProduct.keywords ) {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			featureUnderProduct.keywords!.forEach( ( keyword ) => {
+				expect( screen.getByTestId( 'selected-feature-keywords' ) ).toHaveTextContent( keyword );
+			} );
+		} else {
+			expect( screen.getByText( 'None' ) ).toBeInTheDocument();
+		}
 	} );
 
 	test( 'Selecting a feature records the "feature_select" event with feature and product name', async () => {

--- a/src/feature-selector-form/feature-selector-form.module.css
+++ b/src/feature-selector-form/feature-selector-form.module.css
@@ -96,10 +96,7 @@ button.clearButton:active {
 	color: var( --color-primary-dark );
 }
 
-.selectedFeatureBreadcrumb {
-	color: var( --color-text-light );
-	font-weight: 300;
-	font-size: var( --font-body-small );
+.selectedFeatureKeywords {
 	margin-top: 1.25rem;
 	overflow-x: hidden;
 	/* This is required to prevent an unnecessary scrollbar. 
@@ -145,6 +142,23 @@ button.clearButton:active {
 
 .tooltip {
 	max-width: 20rem;
+}
+
+.selectedFeatureKeywordTitle {
+	font-size: var( --font-body );
+	font-weight: 500;
+	margin-bottom: 0.375rem;
+}
+
+.keywordsWrapper {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.noKeywords {
+	font-style: italic;
+	color: var( --color-error );
+	font-size: var( --font-header );
 }
 
 @media only screen and ( max-width: 600px ) {

--- a/src/feature-selector-form/feature-selector-form.module.css
+++ b/src/feature-selector-form/feature-selector-form.module.css
@@ -156,9 +156,8 @@ button.clearButton:active {
 }
 
 .noKeywords {
-	font-style: italic;
-	color: var( --color-error );
-	font-size: var( --font-header );
+	color: var( --color-text-primary );
+	font-size: var( --font-body-small );
 }
 
 @media only screen and ( max-width: 600px ) {

--- a/src/feature-selector-form/sub-components/selected-feature-details.tsx
+++ b/src/feature-selector-form/sub-components/selected-feature-details.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectNormalizedReportingConfig } from '../../static-data/reporting-config/reporting-config-slice';
-import { ReactComponent as ChevronRightIcon } from '../../common/svgs/chevron-right.svg';
 import styles from '../feature-selector-form.module.css';
 import { setSelectedFeatureId } from '../feature-selector-form-slice';
 import { useMonitoring } from '../../monitoring/monitoring-provider';
+import { SortedKeywordList } from './sorted-keyword-list';
 
 interface Props {
 	featureId: string;
@@ -13,28 +13,20 @@ interface Props {
 export function SelectedFeatureDetails( { featureId }: Props ) {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
-	const { features, featureGroups, products } = useAppSelector( selectNormalizedReportingConfig );
-	const { name: featureName, description, parentId, parentType } = features[ featureId ];
-
-	let productName: string;
-	let featureGroupName: string | null = null;
-	if ( parentType === 'product' ) {
-		productName = products[ parentId ].name;
-	} else {
-		// Parent is a Feature Group
-		const featureGroup = featureGroups[ parentId ];
-		featureGroupName = featureGroup.name;
-		productName = products[ featureGroup.productId ].name;
-	}
-
-	const BreadcrumbIcon = () => (
-		<ChevronRightIcon aria-label="Is a parent of" className={ styles.breadcrumbIcon } />
-	);
+	const { features } = useAppSelector( selectNormalizedReportingConfig );
+	const { name: featureName, description, keywords } = features[ featureId ];
 
 	const handleClearClick = () => {
 		dispatch( setSelectedFeatureId( null ) );
 		monitoringClient.analytics.recordEvent( 'feature_clear' );
 	};
+
+	let keywordsDisplay: ReactNode;
+	if ( keywords ) {
+		keywordsDisplay = <SortedKeywordList keywords={ keywords } />;
+	} else {
+		keywordsDisplay = <span className={ styles.noKeywords }>None</span>;
+	}
 
 	return (
 		<div>
@@ -61,17 +53,10 @@ export function SelectedFeatureDetails( { featureId }: Props ) {
 				</p>
 			) }
 
-			<h4 className="screenReaderOnly">Breadcrumb for currently selected feature:</h4>
-			<div className={ styles.selectedFeatureBreadcrumb }>
-				{ productName }
-				<BreadcrumbIcon />
-				{ featureGroupName && (
-					<>
-						{ featureGroupName }
-						<BreadcrumbIcon />
-					</>
-				) }
-				{ featureName }
+			<div className={ styles.selectedFeatureKeywords }>
+				<h4 className="screenReaderOnly">Keywords for currently selected feature:</h4>
+				<p className={ styles.selectedFeatureKeywordTitle }>Keywords</p>
+				{ keywordsDisplay }
 			</div>
 		</div>
 	);

--- a/src/feature-selector-form/sub-components/sorted-keyword-list.tsx
+++ b/src/feature-selector-form/sub-components/sorted-keyword-list.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo } from 'react';
+import { Pill } from '../../common/components';
+import styles from '../feature-selector-form.module.css';
+
+interface Props {
+	keywords: string[];
+}
+
+export function SortedKeywordList( { keywords }: Props ) {
+	const sortedKeywords = useMemo( () => {
+		const uniqueKeywords = Array.from( new Set( keywords ) );
+		return uniqueKeywords.sort( ( a, b ) => a.localeCompare( b ) );
+	}, [ keywords ] );
+
+	return (
+		<div
+			data-testid={ 'selected-feature-keywords' }
+			className={ styles.keywordsWrapper }
+			aria-label="Keyword list"
+		>
+			{ sortedKeywords.map( ( keyword ) => (
+				<Pill key={ keyword } keyword={ keyword } />
+			) ) }
+		</div>
+	);
+}


### PR DESCRIPTION
#### What Does This PR Add/Change?

This PR replaces the breadcrumbs with keywords in the selected feature. 

**Mobile (600w)**

![600w](https://user-images.githubusercontent.com/67279475/233377909-d9d43d00-4d8e-4360-b9d2-c5cb73f4b80e.png)

**Desktop**

![Screenshot 2023-04-20 at 15 23 30](https://user-images.githubusercontent.com/67279475/233379880-83a3f2e1-cb40-4b83-8ff0-98c298d05f98.png)


![desktop](https://user-images.githubusercontent.com/67279475/233377918-78f942af-1c4a-4171-ade3-7c4e9b4a28eb.png)

**No keywords**

The text 'None' is displayed (context: p1681920814929669/1681912735.521489-slack-CQD1HH4MA)

NOTE: I used the same style for the bad tasks. I'm open to updating the style if needed! (cc: @john-legg )

![no-keywords](https://user-images.githubusercontent.com/67279475/233378303-9633b15c-aa97-4daf-be5f-2258aa40d3ac.png)

 
#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

* Run `yarn start`
* Test that the keywords (when available) are displayed when you selected a feature. 
* Test that the text `None` is displayed when keywords are not available. 
* Verify that the breadcrumbs are still displayed at the completed step 

* All tests should pass. 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #55 