### PR TITLE
Add the search input, and catch up on some tests

### DIFF
--- a/src/common/components/debounced-search.module.css
+++ b/src/common/components/debounced-search.module.css
@@ -1,3 +1,5 @@
+@import '../../variables.css';
+
 .wrapper {
 	position: relative;
 	display: flex;
@@ -10,19 +12,21 @@ input[type='text'].search {
 
 button.button {
 	position: absolute;
-	height: 100%;
 	background: transparent;
 	border: none;
-	right: 0;
-	top: 0;
+	/* Account for the input borders */
+	right: 1px;
+	top: 1px;
+	bottom: 1px;
 	padding: 0 0.5rem;
-	border: 2px solid transparent;
 }
 
-button.button:hover,
-button.button:focus {
-	border: 2px solid var( --color-primary );
-	outline: none;
+button.button:hover {
+	background-color: var( --color-neutral-extra-light );
+}
+
+button.button:active {
+	background-color: var( --color-neutral-light );
 }
 
 .searchIcon {

--- a/src/common/components/debounced-search.tsx
+++ b/src/common/components/debounced-search.tsx
@@ -6,6 +6,7 @@ import { ReactComponent as SearchIcon } from '../svgs/search.svg';
 interface Props {
 	callback: ( searchTerm: string ) => void;
 	debounceMs?: number;
+	debounceCharacterMinimum?: number;
 	placeholder?: string;
 	className?: string;
 	inputAriaControls?: string;
@@ -15,6 +16,7 @@ interface Props {
 export function DebouncedSearch( {
 	callback,
 	debounceMs = 300,
+	debounceCharacterMinimum = 0,
 	placeholder = 'Search',
 	className,
 	inputAriaControls,
@@ -26,18 +28,23 @@ export function DebouncedSearch( {
 		[ callback, debounceMs ]
 	);
 
-	const flushDebounce = () => debouncedCallback.flush();
+	const searchImmediately = () => {
+		debouncedCallback.cancel();
+		callback( searchTerm );
+	};
 
 	const handleEnter = ( event: React.KeyboardEvent ) => {
 		if ( event.key === 'Enter' ) {
-			flushDebounce();
+			searchImmediately();
 		}
 	};
 
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const newSearchTerm = event.target.value;
 		setSearchTerm( newSearchTerm );
-		debouncedCallback( newSearchTerm );
+		if ( newSearchTerm.length >= debounceCharacterMinimum ) {
+			debouncedCallback( newSearchTerm );
+		}
 	};
 
 	const classNames = [ styles.search ];
@@ -52,14 +59,14 @@ export function DebouncedSearch( {
 				placeholder={ placeholder }
 				type="text"
 				value={ searchTerm }
-				onBlur={ flushDebounce }
+				onBlur={ searchImmediately }
 				onChange={ handleChange }
 				onKeyUp={ handleEnter }
 				aria-label={ inputAriaLabel }
 				aria-controls={ inputAriaControls }
 			/>
 			<button
-				onClick={ flushDebounce }
+				onClick={ searchImmediately }
 				className={ styles.button }
 				tabIndex={ -1 }
 				aria-hidden={ true }

--- a/src/common/components/form-error-message.module.css
+++ b/src/common/components/form-error-message.module.css
@@ -1,3 +1,5 @@
+@import '../../variables.css';
+
 .errorMessage {
 	font-size: var( --font-body-small );
 	color: var( --color-error );

--- a/src/duplicate-search/__tests__/duplicate-search-controls.test.tsx
+++ b/src/duplicate-search/__tests__/duplicate-search-controls.test.tsx
@@ -27,10 +27,14 @@ describe( '[DuplicateSearchControls]', () => {
 		loadError: null,
 	};
 	const defaultInitialSearchState: DuplicateSearchState = {
-		searchTerm: 'foo bar',
+		searchTerm: '',
 		statusFilter: 'all',
 		activeRepoFilters: [],
 		sort: 'relevance',
+	};
+	const searchStateWithSearchTerm: DuplicateSearchState = {
+		...defaultInitialSearchState,
+		searchTerm: 'foo bar',
 	};
 
 	function setup( component: ReactElement, preLoadedState?: Partial< RootState > ) {
@@ -96,6 +100,14 @@ describe( '[DuplicateSearchControls]', () => {
 
 			expect( apiClient.searchIssues ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		test( "If you change another parameter while the search input is empty, it doesn't search", async () => {
+			const { user, apiClient } = setup( <DuplicateSearchControls /> );
+
+			await user.click( screen.getByRole( 'option', { name: 'Open' } ) );
+
+			expect( apiClient.searchIssues ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Status filter', () => {
@@ -115,11 +127,13 @@ describe( '[DuplicateSearchControls]', () => {
 		} );
 
 		test( 'Selecting a new filter triggers a new search with the selected status filter', async () => {
-			const { apiClient, user } = setup( <DuplicateSearchControls /> );
+			const { apiClient, user } = setup( <DuplicateSearchControls />, {
+				duplicateSearch: searchStateWithSearchTerm,
+			} );
 
 			await user.click( screen.getByRole( 'option', { name: 'Closed' } ) );
 
-			expect( apiClient.searchIssues ).toHaveBeenCalledWith( defaultInitialSearchState.searchTerm, {
+			expect( apiClient.searchIssues ).toHaveBeenCalledWith( searchStateWithSearchTerm.searchTerm, {
 				status: 'closed',
 				sort: defaultInitialSearchState.sort,
 				repos: defaultInitialSearchState.activeRepoFilters,
@@ -127,7 +141,9 @@ describe( '[DuplicateSearchControls]', () => {
 		} );
 
 		test( 'Selecting the same filter does not trigger a new search', async () => {
-			const { apiClient, user } = setup( <DuplicateSearchControls /> );
+			const { apiClient, user } = setup( <DuplicateSearchControls />, {
+				duplicateSearch: searchStateWithSearchTerm,
+			} );
 
 			await user.click( screen.getByRole( 'option', { name: 'All' } ) );
 
@@ -224,7 +240,9 @@ describe( '[DuplicateSearchControls]', () => {
 		} );
 
 		test( 'Clicking "Cancel" closes popover, but does not fire a new search or save repos', async () => {
-			const { apiClient } = setup( <DuplicateSearchControls /> );
+			const { apiClient } = setup( <DuplicateSearchControls />, {
+				duplicateSearch: searchStateWithSearchTerm,
+			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Repository filter' } ) );
 			await userEvent.click( screen.getByRole( 'option', { name: 'Manual' } ) );
@@ -249,7 +267,9 @@ describe( '[DuplicateSearchControls]', () => {
 		} );
 
 		test( 'Clicking "Filter" closes popover and fires a new search', async () => {
-			const { apiClient } = setup( <DuplicateSearchControls /> );
+			const { apiClient } = setup( <DuplicateSearchControls />, {
+				duplicateSearch: searchStateWithSearchTerm,
+			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Repository filter' } ) );
 			await userEvent.click( screen.getByRole( 'button', { name: 'Filter' } ) );
@@ -261,13 +281,15 @@ describe( '[DuplicateSearchControls]', () => {
 		} );
 
 		test( 'Filtering on default mode searches with no repo filters', async () => {
-			const { apiClient } = setup( <DuplicateSearchControls /> );
+			const { apiClient } = setup( <DuplicateSearchControls />, {
+				duplicateSearch: searchStateWithSearchTerm,
+			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Repository filter' } ) );
 			await userEvent.click( screen.getByRole( 'button', { name: 'Filter' } ) );
 
 			expect( apiClient.searchIssues ).toHaveBeenCalledWith(
-				defaultInitialSearchState.searchTerm,
+				searchStateWithSearchTerm.searchTerm,
 				expect.objectContaining( {
 					repos: [],
 				} )
@@ -275,14 +297,16 @@ describe( '[DuplicateSearchControls]', () => {
 		} );
 
 		test( 'Filtering on manual mode with nothing selected searches with no repo filters', async () => {
-			const { apiClient } = setup( <DuplicateSearchControls /> );
+			const { apiClient } = setup( <DuplicateSearchControls />, {
+				duplicateSearch: searchStateWithSearchTerm,
+			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Repository filter' } ) );
 			await userEvent.click( screen.getByRole( 'option', { name: 'Manual' } ) );
 			await userEvent.click( screen.getByRole( 'button', { name: 'Filter' } ) );
 
 			expect( apiClient.searchIssues ).toHaveBeenCalledWith(
-				defaultInitialSearchState.searchTerm,
+				searchStateWithSearchTerm.searchTerm,
 				expect.objectContaining( {
 					repos: [],
 				} )
@@ -290,7 +314,9 @@ describe( '[DuplicateSearchControls]', () => {
 		} );
 
 		test( 'Filtering on manual mode with repos selected searches with the checked repos', async () => {
-			const { apiClient } = setup( <DuplicateSearchControls /> );
+			const { apiClient } = setup( <DuplicateSearchControls />, {
+				duplicateSearch: searchStateWithSearchTerm,
+			} );
 
 			await userEvent.click( screen.getByRole( 'button', { name: 'Repository filter' } ) );
 			await userEvent.click( screen.getByRole( 'option', { name: 'Manual' } ) );
@@ -307,7 +333,7 @@ describe( '[DuplicateSearchControls]', () => {
 			await userEvent.click( screen.getByRole( 'button', { name: 'Filter' } ) );
 
 			expect( apiClient.searchIssues ).toHaveBeenCalledWith(
-				defaultInitialSearchState.searchTerm,
+				searchStateWithSearchTerm.searchTerm,
 				expect.objectContaining( {
 					repos: [ availableRepoFilters[ 0 ], availableRepoFilters[ 1 ] ],
 				} )

--- a/src/duplicate-search/duplicate-search-controls.module.css
+++ b/src/duplicate-search/duplicate-search-controls.module.css
@@ -5,6 +5,14 @@
 	width: 1.5rem;
 }
 
+.searchWrapper {
+	margin: 0.5rem 0;
+}
+
+.statusFilterWrapper {
+	width: 16rem;
+}
+
 .filterSortBar {
 	display: flex;
 	flex-direction: row;

--- a/src/duplicate-search/duplicate-search-controls.tsx
+++ b/src/duplicate-search/duplicate-search-controls.tsx
@@ -15,7 +15,7 @@ export function DuplicateSearchControls() {
 
 	return (
 		<section>
-			<div>
+			<div className={ styles.searchWrapper }>
 				<DebouncedSearch
 					placeholder="Search"
 					callback={ handleSearchTerm }

--- a/src/duplicate-search/duplicate-search-controls.tsx
+++ b/src/duplicate-search/duplicate-search-controls.tsx
@@ -17,7 +17,7 @@ export function DuplicateSearchControls() {
 		<section>
 			<div className={ styles.searchWrapper }>
 				<DebouncedSearch
-					placeholder="Search"
+					placeholder="Search for duplicate issues"
 					callback={ handleSearchTerm }
 					inputAriaLabel="Search for duplicate issues"
 					debounceMs={ 500 }

--- a/src/duplicate-search/duplicate-search-controls.tsx
+++ b/src/duplicate-search/duplicate-search-controls.tsx
@@ -21,6 +21,7 @@ export function DuplicateSearchControls() {
 					callback={ handleSearchTerm }
 					inputAriaLabel="Search for duplicate issues"
 					debounceMs={ 500 }
+					debounceCharacterMinimum={ 3 }
 				/>
 			</div>
 			<div className={ styles.filterSortBar }>

--- a/src/duplicate-search/duplicate-search-controls.tsx
+++ b/src/duplicate-search/duplicate-search-controls.tsx
@@ -1,35 +1,28 @@
 import React from 'react';
-import { useAppDispatch, useAppSelector } from '../app/hooks';
-import { selectAvailableRepoFilters } from '../static-data/available-repo-filters/available-repo-filters-slice';
-import {
-	setActiveRepoFilters,
-	setSearchTerm,
-	setSort,
-	setStatusFilter,
-	setSearchParam,
-} from './duplicate-search-slice';
 import { RepoFilter, StatusFilter } from './sub-components';
+import { useAppDispatch } from '../app/hooks';
+import { setSearchTerm, setSearchParam } from './duplicate-search-slice';
+import { DebouncedSearch } from '../common/components';
 import styles from './duplicate-search-controls.module.css';
 
 // TODO: This is a placeholder component for the duplicate search controls. Modify and tweak however needed! :)
 export function DuplicateSearchControls() {
 	const dispatch = useAppDispatch();
-	const repoFilters = useAppSelector( selectAvailableRepoFilters );
 
-	const handleFauxSearch = () => {
-		dispatch( setSearchTerm( 'Test search term' ) );
-		dispatch( setStatusFilter( 'open' ) );
-		dispatch( setActiveRepoFilters( [] ) );
-
-		// What the dispatch in most components will actually look like
-		dispatch( setSearchParam( setSort( 'relevance' ) ) );
+	const handleSearchTerm = ( searchTerm: string ) => {
+		dispatch( setSearchParam( setSearchTerm( searchTerm ) ) );
 	};
 
 	return (
 		<section>
-			<p>This is just a filler component</p>
-			<button onClick={ handleFauxSearch }>Faux search</button>
-			<p>Available repo filters: { repoFilters.join( ', ' ) }</p>
+			<div>
+				<DebouncedSearch
+					placeholder="Search"
+					callback={ handleSearchTerm }
+					inputAriaLabel="Search for duplicate issues"
+					debounceMs={ 500 }
+				/>
+			</div>
 			<div className={ styles.filterSortBar }>
 				<div className={ styles.filterControls }>
 					<StatusFilter />

--- a/src/duplicate-search/duplicate-search-slice.ts
+++ b/src/duplicate-search/duplicate-search-slice.ts
@@ -143,10 +143,15 @@ type SearchAction =
 // But, I think it will read nicely in the components.
 // E.g. dispatch( setSearchParam( setSearchTerm( 'foo' ) ) );
 export function setSearchParam( action: SearchAction ): AppThunk {
-	return ( dispatch ) => {
+	return ( dispatch, getState ) => {
 		dispatch( action );
 		dispatch( updateHistoryWithState() );
-		dispatch( searchIssues() );
+
+		// We don't want to trigger any searches if we have an empty search term
+		const searchTerm = selectDuplicateSearchTerm( getState() );
+		if ( searchTerm.trim() !== '' ) {
+			dispatch( searchIssues() );
+		}
 	};
 }
 

--- a/src/duplicate-searching-page/__tests__/duplicate-searching-page.test.tsx
+++ b/src/duplicate-searching-page/__tests__/duplicate-searching-page.test.tsx
@@ -1,0 +1,100 @@
+import React, { ReactElement } from 'react';
+import { createMockApiClient } from '../../test-utils/mock-api-client';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test-utils/render-with-providers';
+import { AvailableRepoFiltersState } from '../../static-data/available-repo-filters/types';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { DuplicateSearchingPage } from '../duplicate-searching-page';
+import { SearchIssueApiResponse } from '../../api/types';
+import { Issue } from '../../duplicate-results/types';
+
+describe( '[DuplicateSearchingPage]', () => {
+	const fakeIssue: Issue = {
+		title: 'Test Issue Title',
+		url: 'https://github.com/test/test/issues/1',
+		content: 'Fake issue content.',
+		status: 'open',
+		dateCreated: new Date().toISOString(),
+		dateUpdated: new Date().toISOString(),
+		author: 'Fake Testing User',
+		repo: 'Testorg/Testrepo',
+	};
+
+	const availableRepoFilters = [ 'fakeOrg/fakeRepo', 'otherOrg/otherRepo' ];
+	const availableRepoFiltersState: AvailableRepoFiltersState = {
+		repos: availableRepoFilters,
+		loadError: null,
+	};
+
+	function setup( component: ReactElement ) {
+		const apiClient = createMockApiClient();
+		const user = userEvent.setup();
+		const view = renderWithProviders( component, {
+			apiClient,
+			preloadedState: {
+				availableRepoFilters: availableRepoFiltersState,
+			},
+		} );
+
+		return {
+			user,
+			apiClient,
+			...view,
+		};
+	}
+
+	async function search( user: ReturnType< typeof userEvent.setup >, searchTerm: string ) {
+		await user.click( screen.getByRole( 'textbox', { name: 'Search for duplicate issues' } ) );
+		await user.keyboard( searchTerm );
+		// Bypass debouncing by hitting enter
+		await user.keyboard( '{Enter}' );
+	}
+
+	describe( 'Search results lifecycle', () => {
+		test( 'Initially, shows the search results placeholder', () => {
+			setup( <DuplicateSearchingPage /> );
+
+			expect(
+				screen.getByRole( 'heading', { name: 'Enter some keywords to search for duplicates.' } )
+			).toBeInTheDocument();
+		} );
+
+		test( 'When searching, shows loading indicator, then results when search is done', async () => {
+			const { apiClient, user } = setup( <DuplicateSearchingPage /> );
+
+			let resolveSearchIssuesPromise: ( results: SearchIssueApiResponse ) => void;
+			const searchIssuesPromise = new Promise< SearchIssueApiResponse >( ( resolve ) => {
+				resolveSearchIssuesPromise = resolve;
+			} );
+			apiClient.searchIssues.mockReturnValue( searchIssuesPromise );
+
+			await search( user, 'foo' );
+
+			expect(
+				screen.getByRole( 'alert', { name: 'Duplicate search in progress' } )
+			).toBeInTheDocument();
+
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			resolveSearchIssuesPromise!( [ fakeIssue ] );
+
+			await waitForElementToBeRemoved( () =>
+				screen.queryByRole( 'alert', { name: 'Duplicate search in progress' } )
+			);
+
+			expect(
+				screen.getByRole( 'list', { name: 'Duplicate issue search results' } )
+			).toBeInTheDocument();
+		} );
+
+		test( 'If no search results are found, shows message about no results', async () => {
+			const { apiClient, user } = setup( <DuplicateSearchingPage /> );
+
+			apiClient.searchIssues.mockResolvedValue( [] );
+
+			await search( user, 'foo' );
+			expect(
+				await screen.findByRole( 'heading', { name: 'No results found.' } )
+			).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/src/index.css
+++ b/src/index.css
@@ -41,12 +41,6 @@ body {
 	box-sizing: border-box;
 }
 
-.root input[type='text']:hover,
-.root input[type='search']:hover,
-.root input[type='email']:hover {
-	background-color: var( --color-neutral-extra-light );
-}
-
 .root input[type='text']:focus,
 .root input[type='search']:focus,
 .root input[type='email']:focus {

--- a/src/index.css
+++ b/src/index.css
@@ -35,18 +35,24 @@ body {
 	font-family: var( --font-san-serif );
 	padding: 0.75rem 0.5rem;
 	width: 100%;
-	border-radius: 4px;
+	border-radius: 2px;
 	background-color: var( --color-white );
-	border: 2px solid var( --color-border-dark );
+	border: 1px solid var( --color-border-dark );
 	box-sizing: border-box;
+}
+
+.root input[type='text']:hover,
+.root input[type='search']:hover,
+.root input[type='email']:hover {
+	outline: 1px solid var( --color-border-dark );
 }
 
 .root input[type='text']:focus,
 .root input[type='search']:focus,
 .root input[type='email']:focus {
 	background-color: var( --color-white );
-	border: 2px solid var( --color-primary );
-	outline: none;
+	border: 1px solid var( --color-primary );
+	outline: 1px solid var( --color-primary );
 }
 
 .root input[type='radio'],

--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,7 @@ body {
 .root input[type='text']:hover,
 .root input[type='search']:hover,
 .root input[type='email']:hover {
-	outline: 1px solid var( --color-border-dark );
+	background-color: var( --color-neutral-extra-light );
 }
 
 .root input[type='text']:focus,


### PR DESCRIPTION
#### What Does This PR Add/Change?

- Adds the search input to the duplicate searching page
- Removes much of the placeholder filler
- Makes search inputs match the style guide more
- Adds handling to not search if there's no search term
- Backfills the component tests for search results over the course of the search lifecycle

#### Testing Instructions

- [x] Unit tests pass
- [x] No Axe devtool errors

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #63 