### PR TITLE
Add feature to allow searching for descriptions

### DIFF
--- a/src/combined-selectors/reporting-config-search-results.ts
+++ b/src/combined-selectors/reporting-config-search-results.ts
@@ -1,10 +1,14 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { includesIgnoringCase } from '../common/lib';
 import { selectFeatureSearchTerm } from '../feature-selector-form/feature-selector-form-slice';
-import { selectNormalizedReportingConfig } from '../static-data/reporting-config/reporting-config-slice';
+import {
+	selectNormalizedReportingConfig,
+	selectIndexedReportingConfig,
+} from '../static-data/reporting-config/reporting-config-slice';
 import {
 	NormalizedReportingConfig,
 	TaskParentEntityType,
+	IndexedReportingConfig,
 } from '../static-data/reporting-config/types';
 import { ReportingConfigSearchResults } from './types';
 import { tokenizeAndNormalize } from '../common/lib';
@@ -12,7 +16,7 @@ import { tokenizeAndNormalize } from '../common/lib';
 function searchReportingConfig(
 	searchTerm: string,
 	reportingConfig: NormalizedReportingConfig,
-	invertedIndex: Map< string, Array< { type: TaskParentEntityType; id: string; weight: number } > >
+	invertedIndex: IndexedReportingConfig
 ): ReportingConfigSearchResults {
 	const { features, featureGroups, products } = reportingConfig;
 	const searchResults: ReportingConfigSearchResults = {
@@ -72,7 +76,7 @@ function searchReportingConfig(
 	const scores: Record< string, { type: TaskParentEntityType; score: number } > = {};
 
 	for ( const token of searchTermTokens ) {
-		const matchingEntities = invertedIndex.get( token ) || [];
+		const matchingEntities = invertedIndex[ token ] || [];
 
 		for ( const { type, id, weight } of matchingEntities ) {
 			if ( ! scores[ id ] ) {
@@ -100,66 +104,13 @@ function searchReportingConfig(
 	return searchResults;
 }
 
-function addTokensToInvertedIndex(
-	entityType: TaskParentEntityType,
-	entityId: string,
-	description: string | undefined,
-	invertedIndex: Map< string, Array< { type: TaskParentEntityType; id: string; weight: number } > >
-) {
-	const descriptionTokens = description ? tokenizeAndNormalize( description ) : [];
-	const tokensWithWeights = [ ...descriptionTokens.map( ( token ) => ( { token, weight: 1 } ) ) ];
-
-	for ( const { token, weight } of tokensWithWeights ) {
-		if ( ! invertedIndex.has( token ) ) {
-			invertedIndex.set( token, [] );
-		}
-
-		const tokenList = invertedIndex.get( token );
-		if ( tokenList ) {
-			tokenList.push( { type: entityType, id: entityId, weight } );
-		}
-	}
-}
-
-function createDescriptionInvertedIndex( reportingConfig: NormalizedReportingConfig ) {
-	const invertedIndex = new Map();
-
-	const { features, featureGroups, products } = reportingConfig;
-
-	for ( const productId in products ) {
-		const product = products[ productId ];
-		addTokensToInvertedIndex( 'product', productId, product.description, invertedIndex );
-	}
-
-	for ( const featureGroupId in featureGroups ) {
-		const featureGroup = featureGroups[ featureGroupId ];
-		addTokensToInvertedIndex(
-			'featureGroup',
-			featureGroupId,
-			featureGroup.description,
-			invertedIndex
-		);
-	}
-
-	for ( const featureId in features ) {
-		const feature = features[ featureId ];
-		addTokensToInvertedIndex( 'feature', featureId, feature.description, invertedIndex );
-	}
-
-	return invertedIndex;
-}
-
 // Searching all of the reporting config is expensive, and these search results are needed by several components.
 // For performance, we need to memo-ize (cache) this piece of derived state.
 // The "createSelector" function lets you  do just that:
 // https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization
 export const selectReportingConfigSearchResults = createSelector(
-	[ selectFeatureSearchTerm, selectNormalizedReportingConfig ],
-	( searchTerm, reportingConfig ) => {
-		return searchReportingConfig(
-			searchTerm,
-			reportingConfig,
-			createDescriptionInvertedIndex( reportingConfig )
-		);
+	[ selectFeatureSearchTerm, selectNormalizedReportingConfig, selectIndexedReportingConfig ],
+	( searchTerm, reportingConfig, indexReportingConfig ) => {
+		return searchReportingConfig( searchTerm, reportingConfig, indexReportingConfig );
 	}
 );

--- a/src/combined-selectors/reporting-config-search-results.ts
+++ b/src/combined-selectors/reporting-config-search-results.ts
@@ -4,10 +4,12 @@ import { selectFeatureSearchTerm } from '../feature-selector-form/feature-select
 import { selectNormalizedReportingConfig } from '../static-data/reporting-config/reporting-config-slice';
 import { NormalizedReportingConfig } from '../static-data/reporting-config/types';
 import { ReportingConfigSearchResults } from './types';
+import { tokenizeAndNormalize } from '../common/lib';
 
 function searchReportingConfig(
 	searchTerm: string,
-	reportingConfig: NormalizedReportingConfig
+	reportingConfig: NormalizedReportingConfig,
+	invertedIndex: Map< string, Array< { id: string; weight: number } > >
 ): ReportingConfigSearchResults {
 	const { features, featureGroups, products } = reportingConfig;
 	const searchResults: ReportingConfigSearchResults = {
@@ -19,7 +21,6 @@ function searchReportingConfig(
 	if ( ! searchTerm ) {
 		return searchResults;
 	}
-
 	for ( const productId in products ) {
 		const product = products[ productId ];
 		if ( includesIgnoringCase( product.name, searchTerm ) ) {
@@ -54,7 +55,87 @@ function searchReportingConfig(
 		}
 	}
 
+	// Finally, search for the search term in the description of the products and feature areas
+	const searchTermTokens = tokenizeAndNormalize( searchTerm );
+	const scores: Record< string, number > = {};
+
+	for ( const token of searchTermTokens ) {
+		const matchingEntities = invertedIndex.get( token ) || [];
+
+		for ( const { id, weight } of matchingEntities ) {
+			if ( ! scores[ id ] ) {
+				scores[ id ] = 0;
+			}
+			scores[ id ] += weight;
+		}
+	}
+
+	const scoreThreshold = 1;
+
+	for ( const entityId in scores ) {
+		if ( scores[ entityId ] >= scoreThreshold ) {
+			if ( products[ entityId ] ) {
+				searchResults.products.add( entityId );
+			} else if ( featureGroups[ entityId ] ) {
+				searchResults.featureGroups.add( entityId );
+				searchResults.products.add( featureGroups[ entityId ].productId );
+			} else if ( features[ entityId ] ) {
+				searchResults.features.add( entityId );
+				if ( features[ entityId ].parentType === 'product' ) {
+					searchResults.products.add( features[ entityId ].parentId );
+				} else {
+					searchResults.featureGroups.add( features[ entityId ].parentId );
+					const parentFeatureGroup = featureGroups[ features[ entityId ].parentId ];
+					searchResults.products.add( parentFeatureGroup.productId );
+				}
+			}
+		}
+	}
+
 	return searchResults;
+}
+
+function addTokensToInvertedIndex(
+	entityId: string,
+	description: string | undefined,
+	invertedIndex: Map< string, Array< { id: string; weight: number } > >
+) {
+	const descriptionTokens = description ? tokenizeAndNormalize( description ) : [];
+	const tokensWithWeights = [ ...descriptionTokens.map( ( token ) => ( { token, weight: 1 } ) ) ];
+
+	for ( const { token, weight } of tokensWithWeights ) {
+		if ( ! invertedIndex.has( token ) ) {
+			invertedIndex.set( token, [] );
+		}
+
+		const tokenList = invertedIndex.get( token );
+		if ( tokenList ) {
+			tokenList.push( { id: entityId, weight } );
+		}
+	}
+}
+
+function createDescriptionInvertedIndex( reportingConfig: NormalizedReportingConfig ) {
+	const invertedIndex = new Map();
+
+	const { features, featureGroups, products } = reportingConfig;
+
+	for ( const productId in products ) {
+		const product = products[ productId ];
+		addTokensToInvertedIndex( productId, product.description, invertedIndex );
+	}
+
+	for ( const featureGroupId in featureGroups ) {
+		const featureGroup = featureGroups[ featureGroupId ];
+		addTokensToInvertedIndex( featureGroupId, featureGroup.description, invertedIndex );
+	}
+
+	for ( const featureId in features ) {
+		const feature = features[ featureId ];
+		addTokensToInvertedIndex( featureId, feature.description, invertedIndex );
+	}
+
+	return invertedIndex;
 }
 
 // Searching all of the reporting config is expensive, and these search results are needed by several components.
@@ -64,6 +145,10 @@ function searchReportingConfig(
 export const selectReportingConfigSearchResults = createSelector(
 	[ selectFeatureSearchTerm, selectNormalizedReportingConfig ],
 	( searchTerm, reportingConfig ) => {
-		return searchReportingConfig( searchTerm, reportingConfig );
+		return searchReportingConfig(
+			searchTerm,
+			reportingConfig,
+			createDescriptionInvertedIndex( reportingConfig )
+		);
 	}
 );

--- a/src/common/lib/string-utils.ts
+++ b/src/common/lib/string-utils.ts
@@ -5,3 +5,13 @@ export function includesIgnoringCase( string: string, substring: string ): boole
 export function replaceSpaces( string: string, replacementCharacter = '_' ): string {
 	return string.replaceAll( / /g, replacementCharacter );
 }
+
+export function tokenizeAndNormalize( string: string ) {
+	// Add more stop words as needed
+	const stopWords = new Set( [ 'a', 'an', 'and', 'the', 'in', 'on', 'at', 'of', 'this', 'to' ] );
+	return string
+		.toLowerCase()
+		.replace( /[^\w\s]|_/g, '' )
+		.split( /\s+/ )
+		.filter( ( word ) => ! stopWords.has( word ) );
+}

--- a/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
@@ -1,5 +1,8 @@
 import React, { ReactElement } from 'react';
-import { NormalizedReportingConfig } from '../../static-data/reporting-config/types';
+import {
+	NormalizedReportingConfig,
+	IndexedReportingConfig,
+} from '../../static-data/reporting-config/types';
 import userEvent from '@testing-library/user-event';
 import { screen } from '@testing-library/react';
 import { FeatureSelectorForm } from '../feature-selector-form';
@@ -83,6 +86,14 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 		},
 	};
 
+	const indexedReportingConfig: IndexedReportingConfig = {
+		backup: [ { type: 'featureGroup', id: 'DEF', weight: 1 } ],
+		blog: [ { type: 'feature', id: 'STU', weight: 1 } ],
+		posts: [ { type: 'feature', id: 'STU', weight: 1 } ],
+		site: [ { type: 'featureGroup', id: 'DEF', weight: 1 } ],
+		traffic: [ { type: 'product', id: 'ABC', weight: 1 } ],
+	};
+
 	async function search( user: ReturnType< typeof userEvent.setup >, searchTerm: string ) {
 		await user.click( screen.getByRole( 'textbox', { name: 'Search for a feature' } ) );
 		await user.keyboard( searchTerm );
@@ -98,7 +109,7 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 			preloadedState: {
 				reportingConfig: {
 					normalized: reportingConfig,
-					indexed: {},
+					indexed: indexedReportingConfig,
 					loadError: null,
 				},
 			},

--- a/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
@@ -27,6 +27,7 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 			ABC: {
 				id: 'ABC',
 				name: 'ABC Product',
+				description: 'The stats tools showing traffic and engagement.',
 				featureGroupIds: [ 'DEF', 'MNO' ],
 				featureIds: [],
 			},
@@ -41,6 +42,7 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 			DEF: {
 				id: 'DEF',
 				name: 'DEF Group',
+				description: 'The paid site backup package.',
 				productId: 'ABC',
 				featureIds: [ 'GHI', 'JKL' ],
 			},
@@ -67,6 +69,7 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 			STU: {
 				id: 'STU',
 				name: 'STU Feature',
+				description: 'Blocks that come from the Newspack plugin (e.g. Blog Posts, Post Carousel)',
 				parentType: 'product',
 				parentId: 'PQR',
 			},
@@ -185,6 +188,52 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 			expect(
 				screen.getByRole( 'button', { expanded: false, name: 'PQR Product' } )
 			).toBeInTheDocument();
+		} );
+
+		test( 'Matching a product description filters to that product collapsed', async () => {
+			const { user } = setup( <FeatureSelectorForm /> );
+			await search( user, 'traffic' );
+
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'ABC Product' } )
+			).toBeInTheDocument();
+
+			// Test important exclusions
+			expect( screen.queryByRole( 'button', { name: 'PQR Product' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: /Group/ } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'option', { name: /Feature/ } ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'Matching a feature group description filters to that feature group and its product', async () => {
+			const { user } = setup( <FeatureSelectorForm /> );
+			await search( user, 'site backup' );
+
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'DEF Group' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'ABC Product' } )
+			).toBeInTheDocument();
+
+			// Test important exclusions
+			expect( screen.queryByRole( 'button', { name: 'PQR Product' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'option', { name: 'GHI Feature' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'option', { name: 'JKL Feature' } ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'Matching a feature description under product filters to that feature and its parent product', async () => {
+			const { user } = setup( <FeatureSelectorForm /> );
+			await search( user, 'blog posts' );
+
+			expect( screen.getByRole( 'option', { name: 'STU Feature' } ) ).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'PQR Product' } )
+			).toBeInTheDocument();
+
+			// Test important exclusions
+			expect( screen.queryByRole( 'button', { name: 'ABC Product' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: /Group/ } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'option', { name: 'VWX Feature' } ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'If no matches are found, shows a no results message', async () => {

--- a/src/static-data/reporting-config/reporting-config-parsers.ts
+++ b/src/static-data/reporting-config/reporting-config-parsers.ts
@@ -341,11 +341,11 @@ function addTokensToInvertedIndex(
 }
 
 export function indexReportingConfig(
-	_response: ReportingConfigApiResponse
+	normalizedReportingConfig: NormalizedReportingConfig
 ): IndexedReportingConfig {
 	const invertedIndex: IndexedReportingConfig = {};
 
-	const { features, featureGroups, products } = normalizeReportingConfig( _response );
+	const { features, featureGroups, products } = normalizedReportingConfig;
 
 	for ( const productId in products ) {
 		const product = products[ productId ];

--- a/src/static-data/reporting-config/reporting-config-parsers.ts
+++ b/src/static-data/reporting-config/reporting-config-parsers.ts
@@ -15,6 +15,7 @@ import {
 	TaskParentEntityType,
 	Tasks,
 } from './types';
+import { tokenizeAndNormalize } from '../../common/lib';
 
 // Defining all the core logic for how we normalize and index reporting configs here.
 // We are keeping this separate from how this logic is used in reducers and thunks.
@@ -316,11 +317,55 @@ function throwReportingConfigError( message: string ): never {
 	throw new Error( `Invalid reporting config: ${ message }` );
 }
 
+function addTokensToInvertedIndex(
+	entityType: TaskParentEntityType,
+	entityId: string,
+	description: string | undefined,
+	invertedIndex: {
+		[ key: string ]: Array< { type: TaskParentEntityType; id: string; weight: number } >;
+	}
+) {
+	const descriptionTokens = description ? tokenizeAndNormalize( description ) : [];
+	const tokensWithWeights = [ ...descriptionTokens.map( ( token ) => ( { token, weight: 1 } ) ) ];
+
+	for ( const { token, weight } of tokensWithWeights ) {
+		if ( ! Object.prototype.hasOwnProperty.call( invertedIndex, token ) ) {
+			invertedIndex[ token ] = [];
+		}
+
+		const tokenList = invertedIndex[ token ];
+		if ( tokenList ) {
+			tokenList.push( { type: entityType, id: entityId, weight } );
+		}
+	}
+}
+
 export function indexReportingConfig(
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	_response: ReportingConfigApiResponse
 ): IndexedReportingConfig {
-	// TODO: create real implementation once we know the indices we need!
+	const invertedIndex: IndexedReportingConfig = {};
 
-	return {};
+	const { features, featureGroups, products } = normalizeReportingConfig( _response );
+
+	for ( const productId in products ) {
+		const product = products[ productId ];
+		addTokensToInvertedIndex( 'product', productId, product.description, invertedIndex );
+	}
+
+	for ( const featureGroupId in featureGroups ) {
+		const featureGroup = featureGroups[ featureGroupId ];
+		addTokensToInvertedIndex(
+			'featureGroup',
+			featureGroupId,
+			featureGroup.description,
+			invertedIndex
+		);
+	}
+
+	for ( const featureId in features ) {
+		const feature = features[ featureId ];
+		addTokensToInvertedIndex( 'feature', featureId, feature.description, invertedIndex );
+	}
+
+	return invertedIndex;
 }

--- a/src/static-data/reporting-config/reporting-config-slice.ts
+++ b/src/static-data/reporting-config/reporting-config-slice.ts
@@ -12,9 +12,7 @@ const initialNormalizedReportingConfig: NormalizedReportingConfig = {
 	tasks: {},
 };
 
-const initialIndexedReportingConfig: IndexedReportingConfig = {
-	foo: 'bar',
-};
+const initialIndexedReportingConfig: IndexedReportingConfig = {};
 
 const initialState: ReportingConfigState = {
 	normalized: initialNormalizedReportingConfig,

--- a/src/static-data/reporting-config/reporting-config-slice.ts
+++ b/src/static-data/reporting-config/reporting-config-slice.ts
@@ -47,7 +47,7 @@ export const reportingConfigSlice = createSlice( {
 
 				try {
 					normalized = normalizeReportingConfig( payload );
-					indexed = indexReportingConfig( payload );
+					indexed = indexReportingConfig( normalized );
 				} catch ( err ) {
 					const error = err as Error;
 					return {

--- a/src/static-data/reporting-config/types.ts
+++ b/src/static-data/reporting-config/types.ts
@@ -20,11 +20,9 @@ export interface NormalizedReportingConfig {
 
 /**
  * Indices built from the reporting configuration to facilitate searching for features.
- * TODO: Implement, once we know what kind of searching we will support
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IndexedReportingConfig {
-	// TODO: figure out what indices we need.
+	[ key: string ]: Array< { type: TaskParentEntityType; id: string; weight: number } >;
 }
 
 export type FeatureParentEntityType = 'product' | 'featureGroup';

--- a/src/static-data/reporting-config/types.ts
+++ b/src/static-data/reporting-config/types.ts
@@ -9,7 +9,7 @@ export interface ReportingConfigState {
 }
 
 /**
- * The issue reporting config noramlized, or "flattened", for easier client operations.
+ * The issue reporting config normalized, or "flattened", for easier client operations.
  */
 export interface NormalizedReportingConfig {
 	features: Features;
@@ -19,8 +19,12 @@ export interface NormalizedReportingConfig {
 }
 
 /**
- * Indices built from the reporting configuration to facilitate searching for features.
- */
+ * Represents an inverted index that allows for searching features by their descriptions.
+ * The index is built by extracting tokens from the description of each product and feature group in the reporting configuration. 
+ * The resulting index is an object whose keys are the extracted tokens, 
+ * and whose values are arrays of objects representing entities containing the token. 
+e
+*/
 export interface IndexedReportingConfig {
 	[ key: string ]: Array< { type: TaskParentEntityType; id: string; weight: number } >;
 }


### PR DESCRIPTION
#### What Does This PR Add/Change?

This PR updates the implementation for displaying search results in feature selection. Users will now be able to see results when a search term matches a description. 

**Key changes:**
1. Used inverted search only for descriptions. 
2. Filtered the search term with stop words before indexing. 
3. Added tests to cover the changes. 

@john-legg looping you in for design-related! I did not see a Figma for this change, but just checking with you if by simply displaying the tree is okay. 

**Test data:** both the feature and feature group has a description that contains `blog posts`

![Screenshot 2023-04-25 at 16 18 22](https://user-images.githubusercontent.com/67279475/234305955-7cc30173-aa51-461f-9b79-c4c05d42eb14.png)

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

* Feel free to explore! Make sure the tests are passing. 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #58 
Closes # 