### PR TITLE
Add re-usable dropdown component API and sort control

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,13 @@ module.exports = {
 			files: [ '**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)' ],
 			extends: [ 'plugin:testing-library/react', 'plugin:jest-dom/recommended' ],
 		},
+		{
+			// The prop-types rule isn't very helpful with TypeScript and can make noise.
+			files: [ '**/*.ts', '**/*.tsx' ],
+			rules: {
+				'react/prop-types': 'off',
+			},
+		},
 	],
 	parserOptions: {
 		ecmaVersion: 'latest',

--- a/src/common/components/dropdown.module.css
+++ b/src/common/components/dropdown.module.css
@@ -8,6 +8,7 @@
 	display: flex;
 	flex-direction: column;
 	padding: 1rem 0;
+	width: max-content;
 }
 
 button.item {

--- a/src/common/components/dropdown.module.css
+++ b/src/common/components/dropdown.module.css
@@ -11,7 +11,8 @@
 	width: max-content;
 }
 
-button.item {
+button.item,
+a.item {
 	background-color: var( --color-white );
 	border: 2px solid transparent;
 	cursor: pointer;
@@ -19,14 +20,17 @@ button.item {
 	padding: 0.5rem 1rem;
 }
 
-button.item:hover {
+button.item:hover,
+a.item:hover {
 	background-color: var( --color-neutral-extra-light );
 }
 
-button.item:active {
+button.item:active,
+a.item:active {
 	background-color: var( --color-neutral-light );
 }
 
-button.item:focus-visible {
+button.item:focus-visible,
+a.item:focus-visible {
 	border-color: var( --color-primary );
 }

--- a/src/common/components/dropdown.module.css
+++ b/src/common/components/dropdown.module.css
@@ -1,0 +1,31 @@
+@import '../../variables.css';
+
+.wrapper {
+	z-index: 2;
+	background-color: var( --color-white );
+	border: 1px solid var( --color-border );
+	box-shadow: 0px 2px 3px -1px rgba( 0, 0, 0, 0.1 );
+	display: flex;
+	flex-direction: column;
+	padding: 1rem 0;
+}
+
+button.item {
+	background-color: var( --color-white );
+	border: 2px solid transparent;
+	cursor: pointer;
+	align-items: center;
+	padding: 0.5rem 1rem;
+}
+
+button.item:hover {
+	background-color: var( --color-neutral-extra-light );
+}
+
+button.item:active {
+	background-color: var( --color-neutral-light );
+}
+
+button.item:focus-visible {
+	border-color: var( --color-primary );
+}

--- a/src/common/components/dropdown.tsx
+++ b/src/common/components/dropdown.tsx
@@ -38,8 +38,8 @@ import styles from './dropdown.module.css';
  *   		{Your trigger element}
  * 		</DropdownTrigger>
  * 		<DropdownContent>
- *  		<DropdownItem label="Item 1" role='menuitem'>Item 1</DropdownItem>
- * 			<DropdownItem label="Item 2" role='menuitem'>Item 2</DropdownItem>
+ *  		<DropdownItem typeaheadLabel="Item 1" role='menuitem'>Item 1</DropdownItem>
+ * 			<DropdownItem typeaheadLabel="Item 2" role='menuitem'>Item 2</DropdownItem>
  * 			{... and so on}
  * 		</DropdownContent>
  * </Dropdown>
@@ -225,7 +225,7 @@ interface DropdownItemProps extends HTMLProps< HTMLElement > {
 	/**
 	 * The label is what is used for matching items when typing.
 	 */
-	label: string;
+	typeaheadLabel: string;
 	/**
 	 * The items can be rendered as buttons or links. Default is button.
 	 */
@@ -234,14 +234,14 @@ interface DropdownItemProps extends HTMLProps< HTMLElement > {
 
 export function DropdownItem( {
 	children,
-	label,
+	typeaheadLabel,
 	onClick,
 	className,
 	as: Component = 'button',
 	...props
 }: DropdownItemProps ) {
 	const { setIsDropdownOpen, activeListIndex, getItemProps } = useDropdownContext();
-	const { ref, index } = useListItem( { label } );
+	const { ref, index } = useListItem( { label: typeaheadLabel } );
 
 	const isActive = activeListIndex === index;
 

--- a/src/common/components/dropdown.tsx
+++ b/src/common/components/dropdown.tsx
@@ -1,5 +1,4 @@
 import React, {
-	ButtonHTMLAttributes,
 	HTMLProps,
 	MouseEventHandler,
 	ReactNode,
@@ -222,8 +221,15 @@ export function DropdownContent( { children, style, ...props }: HTMLProps< HTMLD
 	);
 }
 
-interface DropdownItemProps extends ButtonHTMLAttributes< HTMLButtonElement > {
+interface DropdownItemProps extends HTMLProps< HTMLElement > {
+	/**
+	 * The label is what is used for matching items when typing.
+	 */
 	label: string;
+	/**
+	 * The items can be rendered as buttons or links. Default is button.
+	 */
+	as?: 'button' | 'a';
 }
 
 export function DropdownItem( {
@@ -231,6 +237,7 @@ export function DropdownItem( {
 	label,
 	onClick,
 	className,
+	as: Component = 'button',
 	...props
 }: DropdownItemProps ) {
 	const { setIsDropdownOpen, activeListIndex, getItemProps } = useDropdownContext();
@@ -248,7 +255,7 @@ export function DropdownItem( {
 	const combinedClassName = [ styles.item, className ].join( ' ' );
 
 	return (
-		<button
+		<Component
 			{ ...getItemProps( {
 				ref,
 				onClick: handleClick,
@@ -258,6 +265,6 @@ export function DropdownItem( {
 			} ) }
 		>
 			{ children }
-		</button>
+		</Component>
 	);
 }

--- a/src/common/components/dropdown.tsx
+++ b/src/common/components/dropdown.tsx
@@ -22,15 +22,20 @@ import {
 	FloatingList,
 	useListItem,
 	useListNavigation,
+	Placement,
 } from '@floating-ui/react';
 import styles from './dropdown.module.css';
 
-export function useDropdown() {
+interface DropdownFloatingConfig {
+	placement?: Placement;
+}
+
+export function useDropdown( { placement }: DropdownFloatingConfig ) {
 	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
 	const [ activeListIndex, setActiveListIndex ] = useState< number | null >( null );
 
 	const floatingData = useFloating( {
-		placement: 'bottom-start',
+		placement: placement || 'bottom-start',
 		open: isDropdownOpen,
 		onOpenChange: setIsDropdownOpen,
 		middleware: [ shift() ],
@@ -88,12 +93,12 @@ export const useDropdownContext = () => {
 	return context;
 };
 
-interface DropdownProps {
+interface DropdownProps extends DropdownFloatingConfig {
 	children: ReactNode;
 }
 
-export function Dropdown( { children }: DropdownProps ) {
-	const dropdownData = useDropdown();
+export function Dropdown( { children, ...floatingConfig }: DropdownProps ) {
+	const dropdownData = useDropdown( floatingConfig );
 
 	return <DropdownContext.Provider value={ dropdownData }>{ children }</DropdownContext.Provider>;
 }
@@ -147,6 +152,7 @@ export function DropdownContent( { children, style, ...props }: HTMLProps< HTMLD
 export function DropdownItem( {
 	children,
 	onClick,
+	className,
 	...props
 }: ButtonHTMLAttributes< HTMLButtonElement > ) {
 	const { setIsDropdownOpen, activeListIndex } = useDropdownContext();
@@ -161,12 +167,14 @@ export function DropdownItem( {
 		setIsDropdownOpen( false );
 	};
 
+	const combinedClassName = [ styles.item, className ].join( ' ' );
+
 	return (
 		<button
 			ref={ ref }
 			onClick={ handleClick }
 			tabIndex={ isActive ? 0 : -1 }
-			className={ styles.item }
+			className={ combinedClassName }
 			{ ...props }
 		>
 			{ children }

--- a/src/common/components/dropdown.tsx
+++ b/src/common/components/dropdown.tsx
@@ -1,0 +1,181 @@
+import React, {
+	HTMLProps,
+	ReactNode,
+	cloneElement,
+	createContext,
+	forwardRef,
+	isValidElement,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import {
+	useFloating,
+	shift,
+	autoUpdate,
+	flip,
+	useClick,
+	useDismiss,
+	useRole,
+	useInteractions,
+	useMergeRefs,
+	FloatingFocusManager,
+	FloatingList,
+	useListItem,
+	useListNavigation,
+} from '@floating-ui/react';
+
+export function useDropdown() {
+	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
+	const [ activeListIndex, setActiveListIndex ] = useState< number | null >( null );
+
+	const floatingData = useFloating( {
+		placement: 'bottom-start',
+		open: isDropdownOpen,
+		onOpenChange: setIsDropdownOpen,
+		middleware: [ shift(), flip() ],
+		whileElementsMounted: autoUpdate,
+	} );
+
+	const { context } = floatingData;
+	const click = useClick( context );
+	const dismiss = useDismiss( context );
+	// TODO: set the right role, likely based on props.
+	const role = useRole( context );
+
+	const listElementsRef = useRef< Array< HTMLElement | null > >( [] );
+	const listNavigation = useListNavigation( context, {
+		listRef: listElementsRef,
+		activeIndex: activeListIndex,
+		onNavigate: setActiveListIndex,
+	} );
+
+	// Merge all the interactions into prop getters
+	const interactions = useInteractions( [ click, dismiss, role, listNavigation ] );
+
+	return useMemo( () => {
+		return {
+			isDropdownOpen,
+			setIsDropdownOpen,
+			listElementsRef,
+			activeListIndex,
+			setActiveListIndex,
+			...floatingData,
+			...interactions,
+		};
+	}, [
+		isDropdownOpen,
+		setIsDropdownOpen,
+		listElementsRef,
+		activeListIndex,
+		setActiveListIndex,
+		floatingData,
+		interactions,
+	] );
+}
+
+type DropdownContext = ReturnType< typeof useDropdown > | null;
+
+const DropdownContext = createContext< DropdownContext >( null );
+
+export const useDropdownContext = () => {
+	const context = React.useContext( DropdownContext );
+	if ( ! context ) {
+		throw new Error(
+			'Any Dropdown child components must be wrapped in a parent <Dropdown /> component'
+		);
+	}
+	return context;
+};
+
+interface DropdownProps {
+	children: ReactNode;
+}
+
+export function Dropdown( { children }: DropdownProps ) {
+	const dropdownData = useDropdown();
+
+	return <DropdownContext.Provider value={ dropdownData }>{ children }</DropdownContext.Provider>;
+}
+
+interface DropdownTriggerProps {
+	children: ReactNode;
+}
+
+export const DropdownTrigger = forwardRef<
+	HTMLElement,
+	HTMLProps< HTMLElement > & DropdownTriggerProps
+>( function DropdownTrigger( { children, ...props }, propRef ) {
+	const dropdownContext = useDropdownContext();
+	const mergedRef = useMergeRefs( [ propRef, dropdownContext.refs.setReference ] );
+
+	if ( ! isValidElement( children ) ) {
+		throw new Error( '<DropdownTrigger /> must have a single, valid child element' );
+	}
+
+	return cloneElement(
+		children,
+		dropdownContext.getReferenceProps( {
+			ref: mergedRef,
+			...props,
+			...children.props,
+			'data-state': dropdownContext.isDropdownOpen ? 'open' : 'closed',
+		} )
+	);
+} );
+
+export const DropdownContent = forwardRef< HTMLDivElement, HTMLProps< HTMLDivElement > >(
+	function DropdownContent( { children, style, ...props }, propRef ) {
+		const dropdownContext = useDropdownContext();
+
+		const { x, y, strategy, context, getFloatingProps, refs, listElementsRef } = dropdownContext;
+
+		const mergedRef = useMergeRefs( [ propRef, refs.setFloating ] );
+
+		return (
+			<>
+				{ dropdownContext.isDropdownOpen && (
+					<FloatingFocusManager context={ context } modal={ false }>
+						<div
+							ref={ mergedRef }
+							style={ {
+								position: strategy,
+								top: y ?? 0,
+								left: x ?? 0,
+								...style,
+							} }
+							{ ...getFloatingProps( props ) }
+						>
+							<FloatingList elementsRef={ listElementsRef }>{ children }</FloatingList>
+						</div>
+					</FloatingFocusManager>
+				) }
+			</>
+		);
+	}
+);
+
+export const DropdownItem = forwardRef< HTMLElement, HTMLProps< HTMLElement > >(
+	function DropdownItem( { children, ...props }, propRef ) {
+		const { setIsDropdownOpen, activeListIndex } = useDropdownContext();
+		const { ref, index } = useListItem();
+
+		const mergedRef = useMergeRefs( [ ref, propRef ] );
+		const isActive = activeListIndex === index;
+
+		if ( ! isValidElement( children ) ) {
+			throw new Error( '<DropdownItem /> must have a single, valid child element' );
+		}
+
+		return cloneElement( children, {
+			ref: mergedRef,
+			onClick: () => {
+				children.props.onClick?.();
+				setIsDropdownOpen( false );
+			},
+			tabIndex: isActive ? 0 : -1,
+			...props,
+			...children.props,
+		} );
+	}
+);

--- a/src/common/components/dropdown.tsx
+++ b/src/common/components/dropdown.tsx
@@ -46,6 +46,11 @@ import styles from './dropdown.module.css';
  *
  * You must provide which role the dropdown should have. This is either 'menu' or 'listbox' (the case of a select-only combobox).
  *
+ * TODO: I would love to find a way to implement the typing behavior from this WAI ARIA example:
+ * https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/
+ * But... I'm having a really hard time getting it to play nicely with the FloatingUI API.
+ * Add a KeyDown handler right on the trigger was messing with some of the auto-focus.
+ * Also, because this follows a composable children pattern, we don't know all the labels upfront to pass to useTypeahead.
  */
 
 type DropdownRole = 'menu' | 'listbox';

--- a/src/common/components/dropdown.tsx
+++ b/src/common/components/dropdown.tsx
@@ -5,6 +5,7 @@ import React, {
 	cloneElement,
 	createContext,
 	isValidElement,
+	useContext,
 	useMemo,
 	useRef,
 	useState,
@@ -140,7 +141,7 @@ type DropdownContext = ReturnType< typeof useDropdown > | null;
 const DropdownContext = createContext< DropdownContext >( null );
 
 const useDropdownContext = () => {
-	const context = React.useContext( DropdownContext );
+	const context = useContext( DropdownContext );
 	if ( ! context ) {
 		throw new Error(
 			'Any Dropdown child components must be wrapped in a parent <Dropdown /> component'

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -6,3 +6,4 @@ export * from './animated-ellipsis';
 export * from './loading-indicator';
 export * from './pill';
 export * from './segmented-control';
+export * from './dropdown';

--- a/src/common/svgs/check.svg
+++ b/src/common/svgs/check.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17.9293 7.978L10.7311 17.6588L6.21474 14.3007L7.10977 13.097L10.4224 15.5601L16.7256 7.08297L17.9293 7.978Z" fill="#1E1E1E"/>
+</svg>

--- a/src/common/svgs/sort.svg
+++ b/src/common/svgs/sort.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.2703 14.0376L12.1016 13.2063L15.017 16.1217L15.017 5.78418H16.1926V16.1217L19.108 13.2063L19.9394 14.0376L15.6048 18.3721L11.2703 14.0376Z" fill="#1E1E1E"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12.6692 9.33447L11.8379 10.1658L8.92248 7.25037L8.92247 17.5879L7.74681 17.5879L7.74681 7.25037L4.83142 10.1658L4.0001 9.33446L8.33464 4.99997L12.6692 9.33447Z" fill="#1E1E1E"/>
+</svg>

--- a/src/duplicate-search/duplicate-search-controls.module.css
+++ b/src/duplicate-search/duplicate-search-controls.module.css
@@ -196,3 +196,28 @@ button.repoFilterMassActionButton {
 .repoFilterMassActionButton:active {
 	color: var( --color-primary-extra-dark );
 }
+
+.sortOption {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+.sortCheckIconWrapper {
+	width: 1.5rem;
+	height: 1.5rem;
+	margin-right: 0.5rem;
+}
+
+.sortCheckIcon {
+	height: 1.5rem;
+	width: 1.5rem;
+}
+
+.sortCheckIcon path {
+	fill: var( --color-primary );
+}
+
+.sortOptionLabelWrapper {
+	padding-right: 0.5rem;
+}

--- a/src/duplicate-search/duplicate-search-controls.module.css
+++ b/src/duplicate-search/duplicate-search-controls.module.css
@@ -21,7 +21,7 @@
 	margin-bottom: 1.625rem;
 }
 
-.filterControls {
+.filtersWrapper {
 	display: flex;
 	flex-direction: row;
 	column-gap: 0.625rem;
@@ -220,4 +220,18 @@ button.repoFilterMassActionButton {
 
 .sortOptionLabelWrapper {
 	padding-right: 0.5rem;
+}
+
+@media only screen and ( max-width: 600px ) {
+	.filterSortBar {
+		flex-direction: column;
+		row-gap: 0.625rem;
+		align-items: flex-start;
+	}
+
+	.filtersWrapper {
+		flex-direction: column;
+		row-gap: 0.625rem;
+		align-items: flex-start;
+	}
 }

--- a/src/duplicate-search/duplicate-search-controls.tsx
+++ b/src/duplicate-search/duplicate-search-controls.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch } from '../app/hooks';
 import { setSearchTerm, setSearchParam } from './duplicate-search-slice';
 import { DebouncedSearch } from '../common/components';
 import styles from './duplicate-search-controls.module.css';
+import { SortSelect } from './sub-components/sort-select';
 
 // TODO: This is a placeholder component for the duplicate search controls. Modify and tweak however needed! :)
 export function DuplicateSearchControls() {
@@ -28,6 +29,7 @@ export function DuplicateSearchControls() {
 				<div className={ styles.filterControls }>
 					<StatusFilter />
 					<RepoFilter />
+					<SortSelect />
 				</div>
 			</div>
 		</section>

--- a/src/duplicate-search/duplicate-search-controls.tsx
+++ b/src/duplicate-search/duplicate-search-controls.tsx
@@ -26,7 +26,7 @@ export function DuplicateSearchControls() {
 				/>
 			</div>
 			<div className={ styles.filterSortBar }>
-				<div className={ styles.filterControls }>
+				<div className={ styles.filtersWrapper }>
 					<StatusFilter />
 					<RepoFilter />
 				</div>

--- a/src/duplicate-search/duplicate-search-controls.tsx
+++ b/src/duplicate-search/duplicate-search-controls.tsx
@@ -29,6 +29,8 @@ export function DuplicateSearchControls() {
 				<div className={ styles.filterControls }>
 					<StatusFilter />
 					<RepoFilter />
+				</div>
+				<div>
 					<SortSelect />
 				</div>
 			</div>

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -18,7 +18,7 @@ export function SortSelect() {
 	const currentSortOption = useAppSelector( selectSort );
 	const sortOptions: SortOptions[] = [
 		{
-			label: 'Relevance (default)',
+			label: 'Relevance',
 			value: 'relevance',
 		},
 		{
@@ -27,12 +27,8 @@ export function SortSelect() {
 		},
 	];
 
-	let sortDropdownTriggerLabel = sortOptions.find(
-		( sortOption ) => sortOption.value === currentSortOption
-	)?.label;
-	if ( ! sortDropdownTriggerLabel || sortDropdownTriggerLabel === 'Relevance (default)' ) {
-		sortDropdownTriggerLabel = 'Sort';
-	}
+	const sortDropdownTriggerLabel =
+		sortOptions.find( ( sortOption ) => sortOption.value === currentSortOption )?.label || 'Sort';
 
 	const handleSortOptionClick = useCallback(
 		( sortOptionValue: string ) => {
@@ -55,7 +51,7 @@ export function SortSelect() {
 					<DropdownItem
 						key={ sortOption.value }
 						role="option"
-						label={ sortOption.label }
+						typeaheadLabel={ sortOption.label }
 						aria-selected={ currentSortOption === sortOption.value }
 						className={ styles.sortOption }
 						onClick={ () => handleSortOptionClick( sortOption.value ) }

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from '../../common/components';
+
+export function SortSelect() {
+	return (
+		<Dropdown>
+			<DropdownTrigger>
+				<button>Sort</button>
+			</DropdownTrigger>
+			<DropdownContent>
+				<DropdownItem>
+					<button>Relevance</button>
+				</DropdownItem>
+				<DropdownItem>
+					<button>Date Created</button>
+				</DropdownItem>
+			</DropdownContent>
+		</Dropdown>
+	);
+}

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -5,15 +5,11 @@ export function SortSelect() {
 	return (
 		<Dropdown>
 			<DropdownTrigger>
-				<button>Sort</button>
+				<button aria-haspopup="listbox">Sort</button>
 			</DropdownTrigger>
-			<DropdownContent>
-				<DropdownItem>
-					<button>Relevance</button>
-				</DropdownItem>
-				<DropdownItem>
-					<button>Date Created</button>
-				</DropdownItem>
+			<DropdownContent role="listbox">
+				<DropdownItem role="option">Relevance</DropdownItem>
+				<DropdownItem role="option">Date Created</DropdownItem>
 			</DropdownContent>
 		</Dropdown>
 	);

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -1,15 +1,72 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from '../../common/components';
+import styles from '../duplicate-search-controls.module.css';
+import { IssueSortOption } from '../types';
+import { useAppDispatch, useAppSelector } from '../../app/hooks';
+import { selectSort, setSearchParam, setSort } from '../duplicate-search-slice';
+import { ReactComponent as CheckIcon } from '../../common/svgs/check.svg';
+import { ReactComponent as DownIcon } from '../../common/svgs/chevron-down.svg';
+import { ReactComponent as SortIcon } from '../../common/svgs/sort.svg';
+
+interface SortOptions {
+	label: string;
+	value: IssueSortOption;
+}
 
 export function SortSelect() {
+	const dispatch = useAppDispatch();
+	const currentSortOption = useAppSelector( selectSort );
+	const sortOptions: SortOptions[] = [
+		{
+			label: 'Default',
+			value: 'relevance',
+		},
+		{
+			label: 'Date added',
+			value: 'date-created',
+		},
+	];
+
+	let sortDropdownTriggerLabel = sortOptions.find(
+		( sortOption ) => sortOption.value === currentSortOption
+	)?.label;
+	if ( ! sortDropdownTriggerLabel || sortDropdownTriggerLabel === 'Default' ) {
+		sortDropdownTriggerLabel = 'Sort';
+	}
+
+	const handleSortOptionClick = useCallback(
+		( sortOptionValue: string ) => {
+			dispatch( setSearchParam( setSort( sortOptionValue as IssueSortOption ) ) );
+		},
+		[ dispatch ]
+	);
+
 	return (
-		<Dropdown>
+		<Dropdown placement="bottom-end">
 			<DropdownTrigger>
-				<button aria-haspopup="listbox">Sort</button>
+				<button aria-haspopup="listbox" className={ styles.dropdownButton }>
+					<SortIcon aria-hidden={ true } className={ styles.inlineIcon } />
+					<span>{ sortDropdownTriggerLabel }</span>
+					<DownIcon aria-hidden={ true } className={ styles.inlineIcon } />
+				</button>
 			</DropdownTrigger>
 			<DropdownContent role="listbox">
-				<DropdownItem role="option">Relevance</DropdownItem>
-				<DropdownItem role="option">Date Created</DropdownItem>
+				{ sortOptions.map( ( sortOption ) => (
+					<DropdownItem
+						key={ sortOption.value }
+						role="option"
+						aria-selected={ currentSortOption === sortOption.value }
+						className={ styles.sortOption }
+						onClick={ () => handleSortOptionClick( sortOption.value ) }
+					>
+						<span className={ styles.sortCheckIconWrapper }>
+							{ currentSortOption === sortOption.value && (
+								<CheckIcon className={ styles.sortCheckIcon } />
+							) }
+						</span>
+						<span className={ styles.sortOptionLabelWrapper }>{ sortOption.label }</span>
+					</DropdownItem>
+				) ) }
 			</DropdownContent>
 		</Dropdown>
 	);

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -32,8 +32,8 @@ export function SortSelect() {
 		sortOptions.find( ( sortOption ) => sortOption.value === currentSortOption )?.label || 'Sort';
 
 	const handleSortOptionClick = useCallback(
-		( sortOptionValue: string ) => {
-			dispatch( setSearchParam( setSort( sortOptionValue as IssueSortOption ) ) );
+		( sortOptionValue: IssueSortOption ) => {
+			dispatch( setSearchParam( setSort( sortOptionValue ) ) );
 		},
 		[ dispatch ]
 	);

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from '../../common/components';
 import styles from '../duplicate-search-controls.module.css';
 import { IssueSortOption } from '../types';
@@ -7,6 +7,7 @@ import { selectSort, setSearchParam, setSort } from '../duplicate-search-slice';
 import { ReactComponent as CheckIcon } from '../../common/svgs/check.svg';
 import { ReactComponent as DownIcon } from '../../common/svgs/chevron-down.svg';
 import { ReactComponent as SortIcon } from '../../common/svgs/sort.svg';
+import { Placement } from '@floating-ui/react';
 
 interface SortOptions {
 	label: string;
@@ -37,8 +38,22 @@ export function SortSelect() {
 		[ dispatch ]
 	);
 
+	const [ placement, setPlacement ] = useState< Placement >( getPlacementBasedOnViewport() );
+
+	useEffect( () => {
+		const handleResize = () => {
+			setPlacement( getPlacementBasedOnViewport() );
+		};
+
+		window.addEventListener( 'resize', handleResize );
+
+		return () => {
+			window.removeEventListener( 'resize', handleResize );
+		};
+	}, [] );
+
 	return (
-		<Dropdown placement="bottom-end" role="listbox">
+		<Dropdown placement={ placement } role="listbox">
 			<DropdownTrigger aria-label="Sort results by…">
 				<button className={ styles.dropdownButton }>
 					<SortIcon aria-hidden={ true } className={ styles.inlineIcon } />
@@ -67,4 +82,12 @@ export function SortSelect() {
 			</DropdownContent>
 		</Dropdown>
 	);
+}
+
+function getPlacementBasedOnViewport(): Placement {
+	if ( window.innerWidth <= 600 ) {
+		return 'bottom-start';
+	} else {
+		return 'bottom-end';
+	}
 }

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -18,7 +18,7 @@ export function SortSelect() {
 	const currentSortOption = useAppSelector( selectSort );
 	const sortOptions: SortOptions[] = [
 		{
-			label: 'Default',
+			label: 'Relevance (default)',
 			value: 'relevance',
 		},
 		{
@@ -30,7 +30,7 @@ export function SortSelect() {
 	let sortDropdownTriggerLabel = sortOptions.find(
 		( sortOption ) => sortOption.value === currentSortOption
 	)?.label;
-	if ( ! sortDropdownTriggerLabel || sortDropdownTriggerLabel === 'Default' ) {
+	if ( ! sortDropdownTriggerLabel || sortDropdownTriggerLabel === 'Relevance (default)' ) {
 		sortDropdownTriggerLabel = 'Sort';
 	}
 
@@ -42,26 +42,27 @@ export function SortSelect() {
 	);
 
 	return (
-		<Dropdown placement="bottom-end">
-			<DropdownTrigger>
-				<button aria-haspopup="listbox" className={ styles.dropdownButton }>
+		<Dropdown placement="bottom-end" role="listbox">
+			<DropdownTrigger aria-label="Sort results by…">
+				<button className={ styles.dropdownButton }>
 					<SortIcon aria-hidden={ true } className={ styles.inlineIcon } />
 					<span>{ sortDropdownTriggerLabel }</span>
 					<DownIcon aria-hidden={ true } className={ styles.inlineIcon } />
 				</button>
 			</DropdownTrigger>
-			<DropdownContent role="listbox">
+			<DropdownContent aria-label="Sort options">
 				{ sortOptions.map( ( sortOption ) => (
 					<DropdownItem
 						key={ sortOption.value }
 						role="option"
+						label={ sortOption.label }
 						aria-selected={ currentSortOption === sortOption.value }
 						className={ styles.sortOption }
 						onClick={ () => handleSortOptionClick( sortOption.value ) }
 					>
 						<span className={ styles.sortCheckIconWrapper }>
 							{ currentSortOption === sortOption.value && (
-								<CheckIcon className={ styles.sortCheckIcon } />
+								<CheckIcon aria-hidden="true" className={ styles.sortCheckIcon } />
 							) }
 						</span>
 						<span className={ styles.sortOptionLabelWrapper }>{ sortOption.label }</span>


### PR DESCRIPTION
### What Does This PR Add/Change?

In short, add's the sorting control!

For reference, see: pciE2j-1VQ-p2#comment-1745 (note, we've shifted some of the design slightly since then. Namely, we now just show the exact sort name instead of "Sort" or "Default").

To do that, I've built a re-usable component api: `<Dropdown>`, and its children. See the code comments for more details!
In short though, it's a reusable API for building dropdown style popovers. We will use these in a couple different use cases:
1.  Our custom `select` controls, like this sort filter. 
2. Dropdown menus, like the links to go to the reporting flow and pick the issue type. 

Those behave similarly enough that they can share a lot of the bones!

#### Some a11y notes. 
From an a11y perspective, this sort control is technically a "select-only combobox".
To learn more about comboboxes, you can read up here: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
This page has the example that is closest to our sort control: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/

The one thing that is missing from our control is the ability to open the closed control by typing. I tried for a long time to make this work, but I was reallllly fighting the floating-ui API, and it was compromising some of the other important focus behavior. So, for now, typing works once the popover is open, but doesn't open the popover. This is technically still compliant! We can try to enhance this in the future though.

Two weird things you might note:
- For all `comboboxes`, Mac VO likes to say "start typing". There's sadly not much we can do about that! But it shouldn't be a problem, I think the control's behavior is very self-discoverable.
- Mac VO keyboard navigation is different from the native keyboard navigation on the control! Namely, with Mac VO, you always use the left and right keys to navigate among options. But in this control, for compliance, apart from VO you will use the up and down arrows.

### Testing Instructions

- [x] Unit tests pass
- [x] Axe Devtools is clean

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #62 