### PR TITLE
Fix search handling

### DIFF
--- a/src/common/components/debounced-search.tsx
+++ b/src/common/components/debounced-search.tsx
@@ -49,7 +49,11 @@ export function DebouncedSearch( {
 
 	const searchImmediately = () => {
 		debouncedCallback.cancel();
-		callCallback( searchTerm );
+		const trimmedSearchTerm = searchTerm.trim();
+		// See the comment below on trimming -- after hitting enter, the user would expect to
+		// see the trimmed input in the actual input field.
+		setSearchTerm( trimmedSearchTerm );
+		callCallback( trimmedSearchTerm );
 	};
 
 	const handleEnter = ( event: React.KeyboardEvent ) => {
@@ -61,7 +65,15 @@ export function DebouncedSearch( {
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const newSearchTerm = event.target.value;
 		setSearchTerm( newSearchTerm );
-		debouncedCallback( newSearchTerm );
+		debouncedCallback( newSearchTerm.trim() );
+	};
+
+	// We only ever call the callback with a trimmed search term.
+	// However, trimming the actual value in the input on change, or even on debouncing
+	// feels really weird and clunky to the user. So we only trim the actual value in the
+	// input field on enter (or search button) and on blur.
+	const handleBlur = () => {
+		setSearchTerm( searchTerm.trim() );
 	};
 
 	const classNames = [ styles.search ];
@@ -78,6 +90,7 @@ export function DebouncedSearch( {
 				value={ searchTerm }
 				onChange={ handleChange }
 				onKeyUp={ handleEnter }
+				onBlur={ handleBlur }
 				aria-label={ inputAriaLabel }
 				aria-controls={ inputAriaControls }
 			/>

--- a/src/duplicate-results/duplicate-results.tsx
+++ b/src/duplicate-results/duplicate-results.tsx
@@ -11,11 +11,13 @@ import { ReactComponent as InitialIllustration } from './svgs/initial-illustrati
 import { ReactComponent as NoResultsIllustration } from '../common/svgs/missing-info.svg';
 import { LoadingIndicator } from '../common/components';
 import { selectDuplicateSearchFiltersAreActive } from '../combined-selectors/duplicate-search-filters-are-active';
+import { selectDuplicateSearchTerm } from '../duplicate-search/duplicate-search-slice';
 
 export function DuplicateResults() {
 	const results = useAppSelector( selectDuplicateResults );
 	const resultsRequestStatus = useAppSelector( selectDuplicateResultsRequestStatus );
 	const requestsWereMade = useAppSelector( selectDuplicateRequestsWereMade );
+	const searchTerm = useAppSelector( selectDuplicateSearchTerm );
 	const filtersAreActive = useAppSelector( selectDuplicateSearchFiltersAreActive );
 	const showBanner = useShowBanner();
 
@@ -27,16 +29,16 @@ export function DuplicateResults() {
 	>( undefined );
 
 	useEffect( () => {
-		if ( resultsRequestStatus === 'fulfilled' ) {
+		if ( resultsRequestStatus === 'fulfilled' || searchTerm === '' ) {
 			const newHeight = resultsContainerContentRef.current?.clientHeight;
 			setResultsContainerContentHeightPx( newHeight );
 		}
-	}, [ resultsRequestStatus ] );
+	}, [ resultsRequestStatus, searchTerm ] );
 
 	const resultsLimit = 20; // We can tweak this as needed!
 
 	let resultsContainerDisplay: ReactNode;
-	if ( ! requestsWereMade ) {
+	if ( ! requestsWereMade || searchTerm === '' ) {
 		resultsContainerDisplay = (
 			<PlaceholderMessage
 				illustration={ InitialIllustration }

--- a/src/duplicate-searching-page/__tests__/duplicate-searching-page.test.tsx
+++ b/src/duplicate-searching-page/__tests__/duplicate-searching-page.test.tsx
@@ -96,5 +96,21 @@ describe( '[DuplicateSearchingPage]', () => {
 				await screen.findByRole( 'heading', { name: 'No results found.' } )
 			).toBeInTheDocument();
 		} );
+
+		test( "If user clears their search and presses enter, shows the search results placeholder but still doesn't fire a search", async () => {
+			const { apiClient, user } = setup( <DuplicateSearchingPage /> );
+			apiClient.searchIssues.mockResolvedValue( [ fakeIssue ] );
+
+			await search( user, 'foo' );
+
+			await user.clear( screen.getByRole( 'textbox', { name: 'Search for duplicate issues' } ) );
+			await user.keyboard( '{Enter}' );
+
+			expect(
+				screen.getByRole( 'heading', { name: 'Enter some keywords to search for duplicates.' } )
+			).toBeInTheDocument();
+
+			expect( apiClient.searchIssues ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );


### PR DESCRIPTION
#### What Does This PR Add/Change?

This adds three main fixes to our debounced search handling:
1. If a search term is the exact same as the last emitted search term, we won't debounce it. However, if users still hit enter or the search button, we will emit it. Think of typing "abc", then after the debounce, quickly deleting and re-adding the "c".
2. We remove the forced searching on input blur (lose focus). That was way too eager lol. 
3. If the user clears the search term on the duplicate search page we show the placeholder.

You can basically think of our searching rules as: If the user ever hits enter or the search button, always respond to the behavior. In the case of debouncing, we add optimizations, etc.

One note re: a11y -- we don't trigger any screen reader alerts when the user clears their search. That is intentional! Nothing is actually changing meaningfully in the results (no search is actually firing), so we should avoid spamming the user with alerts.

#### Testing Instructions

- [x] Unit tests pass

Feel free to play around with the duplicate search bar and the feature selector! 👍 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #
