### PR TITLE
Display repositories on selected feature

### DIFF
--- a/src/combined-selectors/__tests__/relevant-task-ids.test.ts
+++ b/src/combined-selectors/__tests__/relevant-task-ids.test.ts
@@ -1,4 +1,4 @@
-import { selectRelevantTaskIds } from '../relevant-task-ids';
+import { selectTaskIdsForCurrentIssueDetails } from '../relevant-task-ids';
 import { NormalizedReportingConfig, TaskDetails } from '../../static-data/reporting-config/types';
 import { createFakeRootState } from '../../test-utils/fake-root-state';
 
@@ -50,7 +50,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectRelevantTaskIds( state );
+		const output = selectTaskIdsForCurrentIssueDetails( state );
 		expect( output ).toEqual( [] );
 	} );
 
@@ -101,7 +101,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectRelevantTaskIds( state );
+		const output = selectTaskIdsForCurrentIssueDetails( state );
 		expect( output ).toEqual( [] );
 	} );
 
@@ -193,7 +193,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectRelevantTaskIds( state );
+		const output = selectTaskIdsForCurrentIssueDetails( state );
 		expect( output ).toEqual( [
 			firstFeatureTaskId,
 			secondFeatureTaskId,
@@ -290,7 +290,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectRelevantTaskIds( state );
+		const output = selectTaskIdsForCurrentIssueDetails( state );
 		expect( output ).toEqual( [ featureTaskId ] );
 	} );
 
@@ -366,7 +366,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectRelevantTaskIds( state );
+		const output = selectTaskIdsForCurrentIssueDetails( state );
 		expect( output ).toEqual( [ featureTaskId ] );
 	} );
 } );

--- a/src/combined-selectors/__tests__/relevant-task-ids.test.ts
+++ b/src/combined-selectors/__tests__/relevant-task-ids.test.ts
@@ -1,8 +1,8 @@
-import { selectTaskIdsForCurrentIssueDetails } from '../relevant-task-ids';
+import { selectTaskIdsForIssueDetails, selectReposForFeature } from '../relevant-task-ids';
 import { NormalizedReportingConfig, TaskDetails } from '../../static-data/reporting-config/types';
 import { createFakeRootState } from '../../test-utils/fake-root-state';
 
-describe( '[selectRelevantTaskIds]', () => {
+describe( '[selectTaskIdsForIssueDetails]', () => {
 	test( 'Returns empty array if there is no feature id in the state', () => {
 		const normalized: NormalizedReportingConfig = {
 			tasks: {
@@ -50,7 +50,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectTaskIdsForCurrentIssueDetails( state );
+		const output = selectTaskIdsForIssueDetails( state );
 		expect( output ).toEqual( [] );
 	} );
 
@@ -101,7 +101,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectTaskIdsForCurrentIssueDetails( state );
+		const output = selectTaskIdsForIssueDetails( state );
 		expect( output ).toEqual( [] );
 	} );
 
@@ -193,7 +193,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectTaskIdsForCurrentIssueDetails( state );
+		const output = selectTaskIdsForIssueDetails( state );
 		expect( output ).toEqual( [
 			firstFeatureTaskId,
 			secondFeatureTaskId,
@@ -290,7 +290,7 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectTaskIdsForCurrentIssueDetails( state );
+		const output = selectTaskIdsForIssueDetails( state );
 		expect( output ).toEqual( [ featureTaskId ] );
 	} );
 
@@ -366,7 +366,195 @@ describe( '[selectRelevantTaskIds]', () => {
 			},
 		} );
 
-		const output = selectTaskIdsForCurrentIssueDetails( state );
+		const output = selectTaskIdsForIssueDetails( state );
 		expect( output ).toEqual( [ featureTaskId ] );
+	} );
+} );
+
+describe( '[selectReposForFeature]', () => {
+	const featureId = 'feature_id';
+
+	test( 'Returns empty array if feature has no tasks', () => {
+		const normalized: NormalizedReportingConfig = {
+			tasks: {},
+			products: {
+				product_id: {
+					id: 'product_id',
+					name: 'Product',
+					featureGroupIds: [],
+					featureIds: [ featureId ],
+				},
+			},
+			featureGroups: {},
+			features: {
+				feature_id: {
+					id: featureId,
+					name: 'Feature',
+					parentType: 'product',
+					parentId: 'product_id',
+					taskMapping: {
+						bug: [],
+						featureRequest: [],
+						urgent: [],
+					},
+				},
+			},
+		};
+
+		const state = createFakeRootState( {
+			reportingConfig: {
+				normalized,
+				indexed: {},
+				loadError: null,
+			},
+
+			issueDetails: {
+				issueType: 'urgent',
+				featureId: featureId,
+				issueTitle: '',
+			},
+			featureSelectorForm: {
+				searchTerm: '',
+				selectedFeatureId: featureId,
+			},
+		} );
+
+		const output = selectReposForFeature( state );
+		expect( output ).toEqual( [] );
+	} );
+
+	test( 'Return empty array if feature has no GitHub tasks', () => {
+		const normalized: NormalizedReportingConfig = {
+			tasks: {
+				feature_task: {
+					id: 'feature_task',
+					parentType: 'feature',
+					parentId: featureId,
+					details: 'Task instructions',
+				},
+			},
+			products: {
+				product_id: {
+					id: 'product_id',
+					name: 'Product',
+					featureGroupIds: [],
+					featureIds: [ featureId ],
+				},
+			},
+			featureGroups: {},
+			features: {
+				feature_id: {
+					id: featureId,
+					name: 'Feature',
+					parentType: 'product',
+					parentId: 'product_id',
+					taskMapping: {
+						bug: [],
+						featureRequest: [],
+						urgent: [],
+					},
+				},
+			},
+		};
+
+		const state = createFakeRootState( {
+			reportingConfig: {
+				normalized,
+				indexed: {},
+				loadError: null,
+			},
+			issueDetails: {
+				issueType: 'urgent',
+				featureId: featureId,
+				issueTitle: '',
+			},
+			featureSelectorForm: {
+				searchTerm: '',
+				selectedFeatureId: featureId,
+			},
+		} );
+
+		const output = selectReposForFeature( state );
+		expect( output ).toEqual( [] );
+	} );
+
+	test( 'Returns the repos for a given feature ID', () => {
+		const featureId = 'feature_id';
+		const featureTaskId = 'feature_task_id';
+		const repo = 'FakeOrg/fake-repo';
+
+		const normalized: NormalizedReportingConfig = {
+			tasks: {
+				[ featureTaskId ]: {
+					id: featureTaskId,
+					parentType: 'feature',
+					parentId: featureId,
+					details: 'Feature GitHub task',
+					link: {
+						type: 'github',
+						labels: [ 'priority-label' ],
+						repository: repo,
+					},
+				},
+				product_task: {
+					id: 'product_task',
+					parentType: 'product',
+					parentId: 'product_id',
+					details: 'Product GitHub task',
+					link: {
+						type: 'github',
+						labels: [ 'other-label' ],
+						repository: repo,
+					},
+				},
+			},
+			products: {
+				product_id: {
+					id: 'product_id',
+					name: 'Product',
+					taskMapping: {
+						bug: [],
+						featureRequest: [],
+						urgent: [ 'product_task' ],
+					},
+					featureGroupIds: [],
+					featureIds: [ featureId ],
+				},
+			},
+			featureGroups: {},
+			features: {
+				[ featureId ]: {
+					id: featureId,
+					name: 'Feature',
+					parentType: 'product',
+					parentId: 'product_id',
+					taskMapping: {
+						bug: [],
+						featureRequest: [],
+						urgent: [ featureTaskId ],
+					},
+				},
+			},
+		};
+
+		const state = createFakeRootState( {
+			reportingConfig: {
+				normalized: normalized,
+				indexed: {},
+				loadError: null,
+			},
+			issueDetails: {
+				issueType: 'bug',
+				featureId: featureId,
+				issueTitle: '',
+			},
+			featureSelectorForm: {
+				searchTerm: '',
+				selectedFeatureId: featureId,
+			},
+		} );
+
+		const output = selectReposForFeature( state );
+		expect( output ).toEqual( [ repo ] );
 	} );
 } );

--- a/src/combined-selectors/all-tasks-are-complete.ts
+++ b/src/combined-selectors/all-tasks-are-complete.ts
@@ -1,10 +1,10 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../app/store';
 import { selectCompletedTasks } from '../next-steps/completed-tasks-slice';
-import { selectTaskIdsForCurrentIssueDetails } from './relevant-task-ids';
+import { selectTaskIdsForIssueDetails } from './relevant-task-ids';
 
 export const selectAllTasksAreComplete = createSelector(
-	[ selectTaskIdsForCurrentIssueDetails, selectCompletedTasks ],
+	[ selectTaskIdsForIssueDetails, selectCompletedTasks ],
 	( relevantTaskIds, completedTaskIds ) => {
 		return allTasksAreComplete( relevantTaskIds, completedTaskIds );
 	}
@@ -13,7 +13,7 @@ export const selectAllTasksAreComplete = createSelector(
 export const makeSelectorToPredictCompletingAllTasks = () =>
 	createSelector(
 		[
-			selectTaskIdsForCurrentIssueDetails,
+			selectTaskIdsForIssueDetails,
 			selectCompletedTasks,
 			( _state: RootState, currentTaskId: string ) => currentTaskId,
 		],

--- a/src/combined-selectors/all-tasks-are-complete.ts
+++ b/src/combined-selectors/all-tasks-are-complete.ts
@@ -1,10 +1,10 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '../app/store';
 import { selectCompletedTasks } from '../next-steps/completed-tasks-slice';
-import { selectRelevantTaskIds } from './relevant-task-ids';
+import { selectTaskIdsForCurrentIssueDetails } from './relevant-task-ids';
 
 export const selectAllTasksAreComplete = createSelector(
-	[ selectRelevantTaskIds, selectCompletedTasks ],
+	[ selectTaskIdsForCurrentIssueDetails, selectCompletedTasks ],
 	( relevantTaskIds, completedTaskIds ) => {
 		return allTasksAreComplete( relevantTaskIds, completedTaskIds );
 	}
@@ -13,7 +13,7 @@ export const selectAllTasksAreComplete = createSelector(
 export const makeSelectorToPredictCompletingAllTasks = () =>
 	createSelector(
 		[
-			selectRelevantTaskIds,
+			selectTaskIdsForCurrentIssueDetails,
 			selectCompletedTasks,
 			( _state: RootState, currentTaskId: string ) => currentTaskId,
 		],

--- a/src/combined-selectors/relevant-task-ids.ts
+++ b/src/combined-selectors/relevant-task-ids.ts
@@ -19,7 +19,7 @@ export const selectRelevantTaskIds = createSelector(
 	}
 );
 
-function getRelevantTaskIds(
+export function getRelevantTaskIds(
 	issueDetails: IssueDetails,
 	reportingConfig: NormalizedReportingConfig
 ): string[] {

--- a/src/feature-selector-form/feature-selector-form.module.css
+++ b/src/feature-selector-form/feature-selector-form.module.css
@@ -150,7 +150,7 @@ button.clearButton:active {
 .selectedFeatureKeywordTitle {
 	font-size: var( --font-body );
 	font-weight: 500;
-	margin-bottom: 0.375rem;
+	margin: 0 0 0.375rem 0;
 }
 
 .keywordsWrapper {

--- a/src/feature-selector-form/feature-selector-form.module.css
+++ b/src/feature-selector-form/feature-selector-form.module.css
@@ -67,6 +67,7 @@ button.selectedFeature:hover {
 	text-decoration: underline;
 }
 
+.repositoriesList,
 .noResultsMessage {
 	color: var( --color-text-light );
 	font-weight: 300;
@@ -96,6 +97,7 @@ button.clearButton:active {
 	color: var( --color-primary-dark );
 }
 
+.selectedFeatureRepositories,
 .selectedFeatureKeywords {
 	margin-top: 1.25rem;
 	overflow-x: hidden;
@@ -144,6 +146,7 @@ button.clearButton:active {
 	max-width: 20rem;
 }
 
+.selectedFeatureRepositoriesTitle,
 .selectedFeatureKeywordTitle {
 	font-size: var( --font-body );
 	font-weight: 500;
@@ -155,7 +158,7 @@ button.clearButton:active {
 	flex-wrap: wrap;
 }
 
-.noKeywords {
+.noResults {
 	color: var( --color-text-primary );
 	font-size: var( --font-body-small );
 }

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -1,7 +1,18 @@
-import React, { FormEventHandler, ReactNode, useCallback, useEffect, useState } from 'react';
+import React, {
+	FormEventHandler,
+	ReactNode,
+	useCallback,
+	useEffect,
+	useState,
+	useMemo,
+} from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { DebouncedSearch, FormErrorMessage } from '../common/components';
-import { selectIssueFeatureId, setIssueFeatureId } from '../issue-details/issue-details-slice';
+import {
+	selectIssueDetails,
+	selectIssueFeatureId,
+	setIssueFeatureId,
+} from '../issue-details/issue-details-slice';
 import { useMonitoring } from '../monitoring/monitoring-provider';
 import {
 	selectNormalizedReportingConfig,
@@ -15,6 +26,7 @@ import {
 import styles from './feature-selector-form.module.css';
 import { FeatureSelectorTree } from './sub-components';
 import { SelectedFeatureDetails } from './sub-components/selected-feature-details';
+import { getRelevantTaskIds } from '../combined-selectors/relevant-task-ids';
 
 interface Props {
 	onContinue?: () => void;
@@ -23,6 +35,8 @@ interface Props {
 export function FeatureSelectorForm( { onContinue }: Props ) {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
+	const issueDetails = useAppSelector( selectIssueDetails );
+	const reportingConfig = useAppSelector( selectNormalizedReportingConfig );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 
 	// On mount, we effectively should 'reset' the form state.
@@ -34,6 +48,16 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 	}, [ dispatch, issueFeatureId ] );
 
 	const selectedFeatureId = useAppSelector( selectSelectedFeatureId );
+
+	const localRelevantTaskIds = useMemo( () => {
+		if ( selectedFeatureId ) {
+			return getRelevantTaskIds(
+				{ ...issueDetails, featureId: selectedFeatureId },
+				reportingConfig
+			);
+		}
+		return [];
+	}, [ selectedFeatureId, issueDetails, reportingConfig ] );
 
 	const { products, features } = useAppSelector( selectNormalizedReportingConfig );
 	const selectedFeatureProductId = useAppSelector( selectProductIdForFeature( selectedFeatureId ) );
@@ -84,7 +108,12 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 			</div>
 		);
 	} else if ( selectedFeatureId ) {
-		bottomPanelDisplay = <SelectedFeatureDetails featureId={ selectedFeatureId } />;
+		bottomPanelDisplay = (
+			<SelectedFeatureDetails
+				featureId={ selectedFeatureId }
+				relevantTaskIds={ localRelevantTaskIds }
+			/>
+		);
 	} else {
 		bottomPanelDisplay = null;
 	}

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -1,18 +1,7 @@
-import React, {
-	FormEventHandler,
-	ReactNode,
-	useCallback,
-	useEffect,
-	useState,
-	useMemo,
-} from 'react';
+import React, { FormEventHandler, ReactNode, useCallback, useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { DebouncedSearch, FormErrorMessage } from '../common/components';
-import {
-	selectIssueDetails,
-	selectIssueFeatureId,
-	setIssueFeatureId,
-} from '../issue-details/issue-details-slice';
+import { selectIssueFeatureId, setIssueFeatureId } from '../issue-details/issue-details-slice';
 import { useMonitoring } from '../monitoring/monitoring-provider';
 import {
 	selectNormalizedReportingConfig,
@@ -26,7 +15,6 @@ import {
 import styles from './feature-selector-form.module.css';
 import { FeatureSelectorTree } from './sub-components';
 import { SelectedFeatureDetails } from './sub-components/selected-feature-details';
-import { getRelevantTaskIds } from '../combined-selectors/relevant-task-ids';
 
 interface Props {
 	onContinue?: () => void;
@@ -35,8 +23,6 @@ interface Props {
 export function FeatureSelectorForm( { onContinue }: Props ) {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
-	const issueDetails = useAppSelector( selectIssueDetails );
-	const reportingConfig = useAppSelector( selectNormalizedReportingConfig );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 
 	// On mount, we effectively should 'reset' the form state.
@@ -48,16 +34,6 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 	}, [ dispatch, issueFeatureId ] );
 
 	const selectedFeatureId = useAppSelector( selectSelectedFeatureId );
-
-	const localRelevantTaskIds = useMemo( () => {
-		if ( selectedFeatureId ) {
-			return getRelevantTaskIds(
-				{ ...issueDetails, featureId: selectedFeatureId },
-				reportingConfig
-			);
-		}
-		return [];
-	}, [ selectedFeatureId, issueDetails, reportingConfig ] );
 
 	const { products, features } = useAppSelector( selectNormalizedReportingConfig );
 	const selectedFeatureProductId = useAppSelector( selectProductIdForFeature( selectedFeatureId ) );
@@ -108,12 +84,7 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 			</div>
 		);
 	} else if ( selectedFeatureId ) {
-		bottomPanelDisplay = (
-			<SelectedFeatureDetails
-				featureId={ selectedFeatureId }
-				relevantTaskIds={ localRelevantTaskIds }
-			/>
-		);
+		bottomPanelDisplay = <SelectedFeatureDetails />;
 	} else {
 		bottomPanelDisplay = null;
 	}

--- a/src/feature-selector-form/sub-components/selected-feature-details.tsx
+++ b/src/feature-selector-form/sub-components/selected-feature-details.tsx
@@ -5,13 +5,13 @@ import styles from '../feature-selector-form.module.css';
 import { selectSelectedFeatureId, setSelectedFeatureId } from '../feature-selector-form-slice';
 import { useMonitoring } from '../../monitoring/monitoring-provider';
 import { SortedKeywordList } from './sorted-keyword-list';
-import { selectAllReposForFormSelectedFeature } from '../../combined-selectors/relevant-task-ids';
+import { selectReposForFeature } from '../../combined-selectors/relevant-task-ids';
 
 export function SelectedFeatureDetails() {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
 	const featureId = useAppSelector( selectSelectedFeatureId );
-	const repositories = useAppSelector( selectAllReposForFormSelectedFeature );
+	const repositories = useAppSelector( selectReposForFeature );
 	const { features } = useAppSelector( selectNormalizedReportingConfig );
 
 	// This should be handled in parent components, but adding for safety, and to keep typing happy.

--- a/src/feature-selector-form/sub-components/selected-feature-details.tsx
+++ b/src/feature-selector-form/sub-components/selected-feature-details.tsx
@@ -44,7 +44,7 @@ export function SelectedFeatureDetails() {
 		const repositoriesList = repositories.join( ', ' );
 		repositoriesDisplay = (
 			<span data-testid={ dataTestId } className={ styles.repositoriesList }>
-				{ repositoriesList }{ ' ' }
+				{ repositoriesList }
 			</span>
 		);
 	} else {

--- a/src/feature-selector-form/sub-components/selected-feature-details.tsx
+++ b/src/feature-selector-form/sub-components/selected-feature-details.tsx
@@ -2,19 +2,23 @@ import React, { ReactNode } from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectNormalizedReportingConfig } from '../../static-data/reporting-config/reporting-config-slice';
 import styles from '../feature-selector-form.module.css';
-import { setSelectedFeatureId } from '../feature-selector-form-slice';
+import { selectSelectedFeatureId, setSelectedFeatureId } from '../feature-selector-form-slice';
 import { useMonitoring } from '../../monitoring/monitoring-provider';
 import { SortedKeywordList } from './sorted-keyword-list';
+import { selectAllReposForFormSelectedFeature } from '../../combined-selectors/relevant-task-ids';
 
-interface Props {
-	featureId: string;
-	relevantTaskIds: string[];
-}
-
-export function SelectedFeatureDetails( { featureId, relevantTaskIds }: Props ) {
+export function SelectedFeatureDetails() {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
-	const { features, tasks } = useAppSelector( selectNormalizedReportingConfig );
+	const featureId = useAppSelector( selectSelectedFeatureId );
+	const repositories = useAppSelector( selectAllReposForFormSelectedFeature );
+	const { features } = useAppSelector( selectNormalizedReportingConfig );
+
+	// This should be handled in parent components, but adding for safety, and to keep typing happy.
+	if ( ! featureId ) {
+		return null;
+	}
+
 	const { name: featureName, description, keywords } = features[ featureId ];
 
 	const handleClearClick = () => {
@@ -31,16 +35,6 @@ export function SelectedFeatureDetails( { featureId, relevantTaskIds }: Props ) 
 				None
 			</span>
 		);
-	}
-
-	const repositories = [];
-
-	for ( const taskId of relevantTaskIds ) {
-		const task = tasks[ taskId ];
-
-		if ( task?.link?.type === 'github' && task.link.repository ) {
-			repositories.push( task.link.repository );
-		}
 	}
 
 	let repositoriesDisplay: ReactNode;

--- a/src/next-steps/next-steps.tsx
+++ b/src/next-steps/next-steps.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useAppSelector } from '../app/hooks';
-import { selectRelevantTaskIds } from '../combined-selectors/relevant-task-ids';
+import { selectTaskIdsForCurrentIssueDetails } from '../combined-selectors/relevant-task-ids';
 import { Task } from './sub-components/task';
 import styles from './next-steps.module.css';
 import { MoreInfo } from './more-info';
@@ -20,7 +20,7 @@ export function NextSteps() {
 
 	const { tasks } = useAppSelector( selectNormalizedReportingConfig );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
-	const relevantTaskIds = useAppSelector( selectRelevantTaskIds );
+	const relevantTaskIds = useAppSelector( selectTaskIdsForCurrentIssueDetails );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
 
 	useEffect( () => {

--- a/src/next-steps/next-steps.tsx
+++ b/src/next-steps/next-steps.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useAppSelector } from '../app/hooks';
-import { selectTaskIdsForCurrentIssueDetails } from '../combined-selectors/relevant-task-ids';
+import { selectTaskIdsForIssueDetails } from '../combined-selectors/relevant-task-ids';
 import { Task } from './sub-components/task';
 import styles from './next-steps.module.css';
 import { MoreInfo } from './more-info';
@@ -20,7 +20,7 @@ export function NextSteps() {
 
 	const { tasks } = useAppSelector( selectNormalizedReportingConfig );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
-	const relevantTaskIds = useAppSelector( selectTaskIdsForCurrentIssueDetails );
+	const relevantTaskIds = useAppSelector( selectTaskIdsForIssueDetails );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
 
 	useEffect( () => {

--- a/src/reporting-flow-page/sub-components/next-steps-step.tsx
+++ b/src/reporting-flow-page/sub-components/next-steps-step.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useCallback } from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectAllTasksAreComplete } from '../../combined-selectors/all-tasks-are-complete';
-import { selectTaskIdsForCurrentIssueDetails } from '../../combined-selectors/relevant-task-ids';
+import { selectTaskIdsForIssueDetails } from '../../combined-selectors/relevant-task-ids';
 import { selectIssueFeatureId, selectIssueType } from '../../issue-details/issue-details-slice';
 import { NextSteps } from '../../next-steps/next-steps';
 import { selectActiveReportingStep } from '../active-reporting-step-slice';
@@ -20,7 +20,7 @@ interface Props {
 
 export function NextStepsStep( { stepNumber }: Props ) {
 	const monitoringClient = useMonitoring();
-	const relevantTaskIds = useAppSelector( selectTaskIdsForCurrentIssueDetails );
+	const relevantTaskIds = useAppSelector( selectTaskIdsForIssueDetails );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 	const issueType = useAppSelector( selectIssueType );

--- a/src/reporting-flow-page/sub-components/next-steps-step.tsx
+++ b/src/reporting-flow-page/sub-components/next-steps-step.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useCallback } from 'react';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { selectAllTasksAreComplete } from '../../combined-selectors/all-tasks-are-complete';
-import { selectRelevantTaskIds } from '../../combined-selectors/relevant-task-ids';
+import { selectTaskIdsForCurrentIssueDetails } from '../../combined-selectors/relevant-task-ids';
 import { selectIssueFeatureId, selectIssueType } from '../../issue-details/issue-details-slice';
 import { NextSteps } from '../../next-steps/next-steps';
 import { selectActiveReportingStep } from '../active-reporting-step-slice';
@@ -20,7 +20,7 @@ interface Props {
 
 export function NextStepsStep( { stepNumber }: Props ) {
 	const monitoringClient = useMonitoring();
-	const relevantTaskIds = useAppSelector( selectRelevantTaskIds );
+	const relevantTaskIds = useAppSelector( selectTaskIdsForCurrentIssueDetails );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 	const issueType = useAppSelector( selectIssueType );

--- a/src/start-over/start-over-card.tsx
+++ b/src/start-over/start-over-card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { selectAllTasksAreComplete } from '../combined-selectors/all-tasks-are-complete';
-import { selectRelevantTaskIds } from '../combined-selectors/relevant-task-ids';
+import { selectTaskIdsForCurrentIssueDetails } from '../combined-selectors/relevant-task-ids';
 import { useMonitoring } from '../monitoring/monitoring-provider';
 import { startOver } from './start-over-counter-slice';
 import { updateHistoryWithState } from '../url-history/actions';
@@ -11,7 +11,7 @@ export function StartOverCard() {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
 
-	const relevantTaskIds = useAppSelector( selectRelevantTaskIds );
+	const relevantTaskIds = useAppSelector( selectTaskIdsForCurrentIssueDetails );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
 
 	if ( relevantTaskIds.length === 0 || ! allTasksAreComplete ) {

--- a/src/start-over/start-over-card.tsx
+++ b/src/start-over/start-over-card.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { selectAllTasksAreComplete } from '../combined-selectors/all-tasks-are-complete';
-import { selectTaskIdsForCurrentIssueDetails } from '../combined-selectors/relevant-task-ids';
+import { selectTaskIdsForIssueDetails } from '../combined-selectors/relevant-task-ids';
 import { useMonitoring } from '../monitoring/monitoring-provider';
 import { startOver } from './start-over-counter-slice';
 import { updateHistoryWithState } from '../url-history/actions';
@@ -11,7 +11,7 @@ export function StartOverCard() {
 	const dispatch = useAppDispatch();
 	const monitoringClient = useMonitoring();
 
-	const relevantTaskIds = useAppSelector( selectTaskIdsForCurrentIssueDetails );
+	const relevantTaskIds = useAppSelector( selectTaskIdsForIssueDetails );
 	const allTasksAreComplete = useAppSelector( selectAllTasksAreComplete );
 
 	if ( relevantTaskIds.length === 0 || ! allTasksAreComplete ) {


### PR DESCRIPTION
#### What Does This PR Add/Change?

This PR displays the (list of) repositories when the user selected a feature.

**Key changes:**
1. A new selector is added to get the repositories of a feature. 
2. New tests for the `selectReposForFeature`
3. Added the list of repositories before the keywords for now. 

![Screenshot 2023-05-04 at 13 43 41](https://user-images.githubusercontent.com/67279475/236194229-9dc462af-70a7-4ce1-afae-02e15f776773.png)

![Screenshot 2023-05-04 at 13 43 47](https://user-images.githubusercontent.com/67279475/236194359-c3967acf-fdf4-4111-b3af-d9cb6387c45c.png)


#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

* Make sure that the tests are passing! 
* Feel free to explore. 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #56 