### PR TITLE
Add error handling/display to duplicate search

### DIFF
--- a/src/duplicate-results/duplicate-results.module.css
+++ b/src/duplicate-results/duplicate-results.module.css
@@ -129,6 +129,10 @@ p.issueContent {
 	height: auto;
 }
 
+.errorIllustration {
+	width: 80px;
+}
+
 h3.placeholderHeader {
 	font-size: var( --font-header );
 	margin-top: 0;

--- a/src/duplicate-results/sub-components/placeholder-message.tsx
+++ b/src/duplicate-results/sub-components/placeholder-message.tsx
@@ -1,8 +1,8 @@
-import React, { FunctionComponent, SVGProps, createElement } from 'react';
+import React, { ReactElement, cloneElement } from 'react';
 import styles from '../duplicate-results.module.css';
 
 interface Props {
-	illustration: FunctionComponent< SVGProps< SVGSVGElement > >;
+	illustration: ReactElement;
 	header: string;
 	message: string;
 	ariaLive?: 'assertive' | 'polite';
@@ -18,8 +18,8 @@ export function PlaceholderMessage( {
 }: Props ) {
 	return (
 		<div className={ styles.placeholderWrapper } aria-live={ ariaLive }>
-			{ createElement( illustration, {
-				className: styles.placeholderIllustration,
+			{ cloneElement( illustration, {
+				className: `${ styles.placeholderIllustration } ${ illustration.props.className }`,
 				'aria-hidden': 'true',
 			} ) }
 			<h3 className={ styles.placeholderHeader }>{ header }</h3>

--- a/src/duplicate-results/sub-components/use-show-banner.ts
+++ b/src/duplicate-results/sub-components/use-show-banner.ts
@@ -14,7 +14,10 @@ export function useShowBanner() {
 	const [ showBanner, setShowBanner ] = useState( requestsWereMade );
 
 	useEffect( () => {
-		if ( requestsWereMade && resultsRequestStatus === 'fulfilled' ) {
+		if (
+			requestsWereMade &&
+			( resultsRequestStatus === 'fulfilled' || resultsRequestStatus === 'error' )
+		) {
 			setShowBanner( true );
 		}
 	}, [ requestsWereMade, resultsRequestStatus ] );

--- a/src/duplicate-searching-page/__tests__/duplicate-searching-page.test.tsx
+++ b/src/duplicate-searching-page/__tests__/duplicate-searching-page.test.tsx
@@ -7,6 +7,7 @@ import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { DuplicateSearchingPage } from '../duplicate-searching-page';
 import { SearchIssueApiResponse } from '../../api/types';
 import { Issue } from '../../duplicate-results/types';
+import { createMockMonitoringClient } from '../../test-utils/mock-monitoring-client';
 
 describe( '[DuplicateSearchingPage]', () => {
 	const fakeIssue: Issue = {
@@ -28,9 +29,11 @@ describe( '[DuplicateSearchingPage]', () => {
 
 	function setup( component: ReactElement ) {
 		const apiClient = createMockApiClient();
+		const monitoringClient = createMockMonitoringClient();
 		const user = userEvent.setup();
 		const view = renderWithProviders( component, {
 			apiClient,
+			monitoringClient,
 			preloadedState: {
 				availableRepoFilters: availableRepoFiltersState,
 			},
@@ -39,6 +42,7 @@ describe( '[DuplicateSearchingPage]', () => {
 		return {
 			user,
 			apiClient,
+			monitoringClient,
 			...view,
 		};
 	}
@@ -111,6 +115,32 @@ describe( '[DuplicateSearchingPage]', () => {
 			).toBeInTheDocument();
 
 			expect( apiClient.searchIssues ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'If the request throws an error, shows error message and logs one error, even if error recurs', async () => {
+			const { apiClient, monitoringClient, user } = setup( <DuplicateSearchingPage /> );
+			const errorMessage = 'Request error message';
+			apiClient.searchIssues.mockRejectedValue( new Error( errorMessage ) );
+
+			await search( user, 'foo' );
+
+			expect(
+				await screen.findByRole( 'heading', { name: 'Uh oh! Something went wrong.' } )
+			).toBeInTheDocument();
+
+			expect( monitoringClient.logger.error ).toHaveBeenCalledWith(
+				'Error in duplicate search request',
+				{
+					errorMessage: `Error: ${ errorMessage }`,
+				}
+			);
+
+			await search( user, 'bar' );
+			expect(
+				await screen.findByRole( 'heading', { name: 'Uh oh! Something went wrong.' } )
+			).toBeInTheDocument();
+
+			expect( monitoringClient.logger.error ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### What Does This PR Add/Change?

We previously didn't handle any request errors when duplicate searching. Now we do!

We show a little error display and log the error (with caching to prevent spam).


#### Testing Instructions

- [x] Unit tests pass

Feel free to play around locally! Just modify the `local-api-client` to throw an error when searching issues. 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #78 