### PR TITLE
Make the URL cleaner and more user friendly

### DIFF
--- a/src/active-page/active-page-slice.ts
+++ b/src/active-page/active-page-slice.ts
@@ -3,9 +3,9 @@ import { RootState } from '../app/store';
 import { updateStateFromHistory } from '../url-history/actions';
 import { ActivePage } from './types';
 
-const initialState: ActivePage = 'duplicateSearching' as ActivePage;
+const initialState: ActivePage = 'duplicate-search' as ActivePage;
 
-const validActivePages = new Set< ActivePage >( [ 'duplicateSearching', 'reportingFlow' ] );
+const validActivePages = new Set< ActivePage >( [ 'duplicate-search', 'report-issue' ] );
 
 export const activePageSlice = createSlice( {
 	name: 'activePage',

--- a/src/active-page/page-navigation-provider.tsx
+++ b/src/active-page/page-navigation-provider.tsx
@@ -69,9 +69,9 @@ export function PageNavigationProvider( { children }: { children: React.ReactNod
 
 function getDocumentTitleForPage( activePage: ActivePage ): string {
 	switch ( activePage ) {
-		case 'duplicateSearching':
+		case 'duplicate-search':
 			return 'Bugomattic - Search for duplicates';
-		case 'reportingFlow':
+		case 'report-issue':
 			return 'Bugomattic - Report a new issue';
 		default:
 			return 'Bugomattic';

--- a/src/active-page/types.ts
+++ b/src/active-page/types.ts
@@ -1,1 +1,1 @@
-export type ActivePage = 'duplicateSearching' | 'reportingFlow';
+export type ActivePage = 'duplicate-search' | 'report-issue';

--- a/src/app-navbar/__tests__/app-navbar.test.tsx
+++ b/src/app-navbar/__tests__/app-navbar.test.tsx
@@ -39,7 +39,7 @@ describe( '[AppNavbar]', () => {
 	}
 
 	test( 'The currently active page is marked as aria-current="page"', async () => {
-		await setup( { activePage: 'reportingFlow' } );
+		await setup( { activePage: 'report-issue' } );
 
 		expect( screen.getByRole( 'menuitem', { name: 'Report an Issue' } ) ).toHaveAttribute(
 			'aria-current',

--- a/src/app-navbar/app-navbar.tsx
+++ b/src/app-navbar/app-navbar.tsx
@@ -43,29 +43,29 @@ export function AppNavbar() {
 		setFocusedMenuItem( menuItem );
 
 		switch ( menuItem ) {
-			case 'duplicateSearching':
+			case 'duplicate-search':
 				duplicateSearchingRef.current?.focus();
 				break;
-			case 'reportingFlow':
+			case 'report-issue':
 				currentReportIssueRef.current?.focus();
 				break;
 		}
 	};
 
 	const goToNextItem = () => {
-		focusMenuItem( 'reportingFlow' );
+		focusMenuItem( 'report-issue' );
 	};
 
 	const goToPreviousItem = () => {
-		focusMenuItem( 'duplicateSearching' );
+		focusMenuItem( 'duplicate-search' );
 	};
 
 	const goToFirstItem = () => {
-		focusMenuItem( 'duplicateSearching' );
+		focusMenuItem( 'duplicate-search' );
 	};
 
 	const goToLastItem = () => {
-		focusMenuItem( 'reportingFlow' );
+		focusMenuItem( 'report-issue' );
 	};
 
 	const handleKeyDown = ( event: React.KeyboardEvent< HTMLUListElement > ) => {
@@ -99,9 +99,9 @@ export function AppNavbar() {
 		<button
 			role="menuitem"
 			ref={ simpleReportIssueRef }
-			aria-current={ currentActivePage === 'reportingFlow' ? 'page' : undefined }
-			tabIndex={ focusedMenuItem === 'reportingFlow' ? 0 : -1 }
-			onClick={ handleMenuItemClick( 'reportingFlow' ) }
+			aria-current={ currentActivePage === 'report-issue' ? 'page' : undefined }
+			tabIndex={ focusedMenuItem === 'report-issue' ? 0 : -1 }
+			onClick={ handleMenuItemClick( 'report-issue' ) }
 			className={ styles.menuItem }
 		>
 			<span className={ styles.menuItemLabel }>Report an Issue</span>
@@ -112,8 +112,8 @@ export function AppNavbar() {
 		<ReportIssueDropdownMenu ref={ dropdownReportIssueRef }>
 			<button
 				role="menuitem"
-				aria-current={ currentActivePage === 'reportingFlow' ? 'page' : undefined }
-				tabIndex={ focusedMenuItem === 'reportingFlow' ? 0 : -1 }
+				aria-current={ currentActivePage === 'report-issue' ? 'page' : undefined }
+				tabIndex={ focusedMenuItem === 'report-issue' ? 0 : -1 }
 				className={ styles.menuItem }
 			>
 				<span className={ styles.menuItemLabel }>
@@ -140,9 +140,9 @@ export function AppNavbar() {
 					<button
 						role="menuitem"
 						ref={ duplicateSearchingRef }
-						aria-current={ currentActivePage === 'duplicateSearching' ? 'page' : undefined }
-						tabIndex={ focusedMenuItem === 'duplicateSearching' ? 0 : -1 }
-						onClick={ handleMenuItemClick( 'duplicateSearching' ) }
+						aria-current={ currentActivePage === 'duplicate-search' ? 'page' : undefined }
+						tabIndex={ focusedMenuItem === 'duplicate-search' ? 0 : -1 }
+						onClick={ handleMenuItemClick( 'duplicate-search' ) }
 						className={ styles.menuItem }
 					>
 						<span className={ styles.menuItemLabel }>Duplicate Search</span>

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -43,7 +43,7 @@ function MainDisplay() {
 	}
 
 	let mainDisplay: ReactNode;
-	if ( activePage === 'duplicateSearching' ) {
+	if ( activePage === 'duplicate-search' ) {
 		mainDisplay = <DuplicateSearchingPage />;
 	} else {
 		mainDisplay = <ReportingFlowPage />;

--- a/src/combined-selectors/__tests__/relevant-task-ids.test.ts
+++ b/src/combined-selectors/__tests__/relevant-task-ids.test.ts
@@ -284,7 +284,7 @@ describe( '[selectTaskIdsForIssueDetails]', () => {
 				loadError: null,
 			},
 			issueDetails: {
-				issueType: 'featureRequest',
+				issueType: 'feature-request',
 				featureId: featureId,
 				issueTitle: '',
 			},

--- a/src/combined-selectors/next-reporting-step.ts
+++ b/src/combined-selectors/next-reporting-step.ts
@@ -5,15 +5,15 @@ import { selectIssueFeatureId } from '../issue-details/issue-details-slice';
 export const selectNextReportingStep = createSelector(
 	[ selectActiveReportingStep, selectIssueFeatureId ],
 	( currentActiveStep, issueFeatureId ) => {
-		if ( currentActiveStep === 'featureSelection' || currentActiveStep === 'nextSteps' ) {
-			return 'nextSteps';
+		if ( currentActiveStep === 'feature' || currentActiveStep === 'next-steps' ) {
+			return 'next-steps';
 		}
 
 		// We are on the first step - selecting issue type
 		if ( issueFeatureId ) {
-			return 'nextSteps';
+			return 'next-steps';
 		}
 
-		return 'featureSelection';
+		return 'feature';
 	}
 );

--- a/src/combined-selectors/relevant-task-ids.ts
+++ b/src/combined-selectors/relevant-task-ids.ts
@@ -49,7 +49,7 @@ function getTaskIdsForFeature(
 	featureId: FeatureId
 ): string[] {
 	const { tasks } = reportingConfig;
-	const allIssueTypes: IssueType[] = [ 'bug', 'featureRequest', 'urgent' ];
+	const allIssueTypes: IssueType[] = [ 'bug', 'feature-request', 'urgent' ];
 	const taskIds = allIssueTypes.flatMap( ( issueType ) =>
 		getTaskIdsForFeatureAndType( reportingConfig, featureId, issueType )
 	);
@@ -70,15 +70,16 @@ function getTaskIdsForFeatureAndType(
 
 	const relevantTasksIds: string[] = [];
 
+	const keyableIssueType = issueType === 'feature-request' ? 'featureRequest' : issueType;
 	const feature = features[ featureId ];
-	const featureTaskIds = feature?.taskMapping?.[ issueType ];
+	const featureTaskIds = feature?.taskMapping?.[ keyableIssueType ];
 	if ( featureTaskIds ) {
 		relevantTasksIds.push( ...featureTaskIds );
 	}
 
 	if ( feature.parentType === 'featureGroup' ) {
 		const featureGroup = featureGroups[ feature.parentId ];
-		const featureGroupTaskIds = featureGroup.taskMapping?.[ issueType ];
+		const featureGroupTaskIds = featureGroup.taskMapping?.[ keyableIssueType ];
 		if ( featureGroupTaskIds ) {
 			relevantTasksIds.push( ...featureGroupTaskIds );
 		}
@@ -93,7 +94,7 @@ function getTaskIdsForFeatureAndType(
 		product = products[ feature.parentId ];
 	}
 
-	const productTaskIds = product.taskMapping?.[ issueType ];
+	const productTaskIds = product.taskMapping?.[ keyableIssueType ];
 	if ( productTaskIds ) {
 		relevantTasksIds.push( ...productTaskIds );
 	}

--- a/src/common/components/report-issue-dropdown-menu.tsx
+++ b/src/common/components/report-issue-dropdown-menu.tsx
@@ -36,7 +36,7 @@ export const ReportIssueDropdownMenu = forwardRef< HTMLElement, Props >(
 				icon: BugIcon,
 			},
 			{
-				value: 'featureRequest',
+				value: 'feature-request',
 				label: 'Request a new feature',
 				icon: FeatureIcon,
 			},

--- a/src/common/components/report-issue-dropdown-menu.tsx
+++ b/src/common/components/report-issue-dropdown-menu.tsx
@@ -53,7 +53,7 @@ export const ReportIssueDropdownMenu = forwardRef< HTMLElement, Props >(
 				// we may have defer more of these actions to calling components.
 				dispatch( setIssueType( issueType ) );
 				dispatch( setActiveReportingStep( nextReportingFlowStep ) );
-				dispatch( setActivePage( 'reportingFlow' ) );
+				dispatch( setActivePage( 'report-issue' ) );
 				dispatch( updateHistoryWithState() );
 
 				if ( additionalOnIssueTypeSelect ) {

--- a/src/duplicate-results/sub-components/report-issue-banner.tsx
+++ b/src/duplicate-results/sub-components/report-issue-banner.tsx
@@ -16,7 +16,7 @@ export function ReportIssueBanner() {
 	const reportingIssueType = useAppSelector( selectIssueType );
 
 	const handleSimpleButtonClick = useCallback( () => {
-		dispatch( setActivePage( 'reportingFlow' ) );
+		dispatch( setActivePage( 'report-issue' ) );
 		dispatch( updateHistoryWithState() );
 	}, [ dispatch ] );
 

--- a/src/issue-details/issue-details-slice.ts
+++ b/src/issue-details/issue-details-slice.ts
@@ -11,7 +11,7 @@ const initialState: IssueDetails = {
 	issueTitle: '',
 };
 
-const validIssueTypes = new Set< IssueType >( [ 'unset', 'bug', 'featureRequest', 'urgent' ] );
+const validIssueTypes = new Set< IssueType >( [ 'unset', 'bug', 'feature-request', 'urgent' ] );
 
 export const issueDetailsSlice = createSlice( {
 	name: 'issueDetails',

--- a/src/issue-details/types.ts
+++ b/src/issue-details/types.ts
@@ -1,4 +1,4 @@
-export type IssueType = 'unset' | 'bug' | 'featureRequest' | 'urgent';
+export type IssueType = 'unset' | 'bug' | 'feature-request' | 'urgent';
 export type FeatureId = string | null;
 export interface IssueDetails {
 	featureId: FeatureId;

--- a/src/reporting-flow-page/active-reporting-step-slice.ts
+++ b/src/reporting-flow-page/active-reporting-step-slice.ts
@@ -7,9 +7,9 @@ import { ActiveReportingStep } from './types';
 const initialState: ActiveReportingStep = 'type' as ActiveReportingStep;
 
 const validActiveReportingSteps = new Set< ActiveReportingStep >( [
-	'featureSelection',
+	'feature',
 	'type',
-	'nextSteps',
+	'next-steps',
 ] );
 
 export const activeReportingStepSlice = createSlice( {

--- a/src/reporting-flow-page/sub-components/feature-selection-step.tsx
+++ b/src/reporting-flow-page/sub-components/feature-selection-step.tsx
@@ -21,12 +21,12 @@ export function FeatureSelectionStep( { stepNumber, goToNextStep }: Props ) {
 	const issueFeatureId = useAppSelector( selectIssueFeatureId );
 
 	const onEdit = useCallback( () => {
-		dispatch( setActiveReportingStep( 'featureSelection' ) );
+		dispatch( setActiveReportingStep( 'feature' ) );
 		dispatch( updateHistoryWithState() );
 		monitoringClient.analytics.recordEvent( 'feature_step_edit' );
 	}, [ dispatch, monitoringClient.analytics ] );
 
-	const isActive = activeStep === 'featureSelection';
+	const isActive = activeStep === 'feature';
 	const isComplete = issueFeatureId !== null && ! isActive;
 
 	let stepContentDisplay: ReactNode;

--- a/src/reporting-flow-page/sub-components/next-steps-step.tsx
+++ b/src/reporting-flow-page/sub-components/next-steps-step.tsx
@@ -28,8 +28,8 @@ export function NextStepsStep( { stepNumber }: Props ) {
 
 	const tasksExist = relevantTaskIds.length > 0;
 	const requiredInfoIsMissing =
-		( issueFeatureId === null || issueType === 'unset' ) && activeStep === 'nextSteps';
-	const noTasksAreConfigured = ! tasksExist && activeStep === 'nextSteps';
+		( issueFeatureId === null || issueType === 'unset' ) && activeStep === 'next-steps';
+	const noTasksAreConfigured = ! tasksExist && activeStep === 'next-steps';
 
 	const memoizedLogError = useLoggerWithCache( monitoringClient.logger.error, [
 		issueFeatureId,

--- a/src/reporting-flow-page/sub-components/page-subheading.tsx
+++ b/src/reporting-flow-page/sub-components/page-subheading.tsx
@@ -11,8 +11,8 @@ export function ReportingPageSubheading() {
 
 	const friendlyStepDescriptions: { [ key in ActiveReportingStep ]: string } = {
 		type: 'Select issue type',
-		featureSelection: 'Select issue feature',
-		nextSteps: 'Next steps to report issue',
+		feature: 'Select issue feature',
+		[ 'next-steps' ]: 'Next steps to report issue',
 	};
 
 	return (

--- a/src/reporting-flow-page/sub-components/type-step.tsx
+++ b/src/reporting-flow-page/sub-components/type-step.tsx
@@ -72,7 +72,7 @@ function getDisplayTextForType( type: IssueType ) {
 			return "It's Urgent!";
 		case 'bug':
 			return 'Bug';
-		case 'featureRequest':
+		case 'feature-request':
 			return 'Feature Request';
 		default:
 			return 'No type set';

--- a/src/reporting-flow-page/types.ts
+++ b/src/reporting-flow-page/types.ts
@@ -1,1 +1,1 @@
-export type ActiveReportingStep = 'type' | 'featureSelection' | 'nextSteps';
+export type ActiveReportingStep = 'type' | 'feature' | 'next-steps';

--- a/src/start-over/__tests__/start-over-banner.test.tsx
+++ b/src/start-over/__tests__/start-over-banner.test.tsx
@@ -47,7 +47,7 @@ describe( '[StartOverBanner]', () => {
 	// This starting state should make the banner appear.
 	const startingState: RootState = {
 		...createFakeRootState(),
-		activePage: 'reportingFlow',
+		activePage: 'report-issue',
 		activeReportingStep: 'next-steps',
 		issueDetails: {
 			issueType: 'bug',

--- a/src/start-over/__tests__/start-over-banner.test.tsx
+++ b/src/start-over/__tests__/start-over-banner.test.tsx
@@ -48,7 +48,7 @@ describe( '[StartOverBanner]', () => {
 	const startingState: RootState = {
 		...createFakeRootState(),
 		activePage: 'reportingFlow',
-		activeReportingStep: 'nextSteps',
+		activeReportingStep: 'next-steps',
 		issueDetails: {
 			issueType: 'bug',
 			featureId: expectedFeatureId,

--- a/src/start-over/start-over-banner.tsx
+++ b/src/start-over/start-over-banner.tsx
@@ -59,12 +59,12 @@ function StartOverDropdownMenu() {
 	const menuOptions: MenuOption[] = [
 		{
 			label: 'Search for duplicates',
-			targetActivePage: 'duplicateSearching',
+			targetActivePage: 'duplicate-search',
 			icon: SearchIcon,
 		},
 		{
 			label: 'Report a new issue',
-			targetActivePage: 'reportingFlow',
+			targetActivePage: 'report-issue',
 			icon: PlusIcon,
 		},
 	];

--- a/src/test-utils/fake-root-state.ts
+++ b/src/test-utils/fake-root-state.ts
@@ -18,7 +18,7 @@ export function createFakeRootState( partialState: Partial< RootState > = {} ): 
 			},
 		},
 
-		activeReportingStep: 'featureSelection',
+		activeReportingStep: 'feature',
 		completedTasks: [],
 		featureSelectorForm: {
 			searchTerm: '',

--- a/src/test-utils/fake-root-state.ts
+++ b/src/test-utils/fake-root-state.ts
@@ -2,7 +2,7 @@ import { RootState } from '../app/store';
 
 export function createFakeRootState( partialState: Partial< RootState > = {} ): RootState {
 	const fakeDefaultRootState: RootState = {
-		activePage: 'duplicateSearching',
+		activePage: 'duplicate-search',
 		availableRepoFilters: {
 			repos: [],
 			loadError: null,

--- a/src/type-form/type-form.tsx
+++ b/src/type-form/type-form.tsx
@@ -90,8 +90,8 @@ export function TypeForm( { onContinue }: Props ) {
 					<label className={ styles.radio }>
 						<input
 							type="radio"
-							checked={ type === 'featureRequest' }
-							value="featureRequest"
+							checked={ type === 'feature-request' }
+							value="feature-request"
 							name="type"
 							onChange={ handleTypeChange }
 							onBlur={ handleTypeBlur }

--- a/src/url-history/__tests__/bad-url-state.test.tsx
+++ b/src/url-history/__tests__/bad-url-state.test.tsx
@@ -69,7 +69,7 @@ describe( '[Bad URL State]', () => {
 					issueType: 'unset',
 					issueTitle: '',
 				},
-				activePage: 'reportingFlow',
+				activePage: 'report-issue',
 				activeReportingStep: 'feature',
 			} as RootState );
 
@@ -88,7 +88,7 @@ describe( '[Bad URL State]', () => {
 					issueType: 'not-a-real-issue-type' as any,
 					issueTitle: '',
 				},
-				activePage: 'reportingFlow',
+				activePage: 'report-issue',
 				activeReportingStep: 'type',
 			} as RootState );
 
@@ -101,7 +101,7 @@ describe( '[Bad URL State]', () => {
 		test( 'Active reporting step that is not part of the predefined list', async () => {
 			const urlQuery = stateToQuery( {
 				activeReportingStep: 'not-a-real-step' as any,
-				activePage: 'reportingFlow',
+				activePage: 'report-issue',
 			} as RootState );
 
 			await setup( urlQuery );
@@ -117,7 +117,7 @@ describe( '[Bad URL State]', () => {
 					issueType: 'bug',
 					issueTitle: '',
 				},
-				activePage: 'reportingFlow',
+				activePage: 'report-issue',
 				activeReportingStep: 'next-steps',
 				completedTasks: [ 'not-an-id' ],
 			} as RootState );
@@ -177,7 +177,7 @@ describe( '[Bad URL State]', () => {
 				issueTitle: '',
 			},
 			activeReportingStep: 'next-steps',
-			activePage: 'reportingFlow',
+			activePage: 'report-issue',
 		} as RootState );
 
 		await setup( urlQuery );

--- a/src/url-history/__tests__/bad-url-state.test.tsx
+++ b/src/url-history/__tests__/bad-url-state.test.tsx
@@ -70,7 +70,7 @@ describe( '[Bad URL State]', () => {
 					issueTitle: '',
 				},
 				activePage: 'reportingFlow',
-				activeReportingStep: 'featureSelection',
+				activeReportingStep: 'feature',
 			} as RootState );
 
 			await setup( urlQuery );
@@ -118,7 +118,7 @@ describe( '[Bad URL State]', () => {
 					issueTitle: '',
 				},
 				activePage: 'reportingFlow',
-				activeReportingStep: 'nextSteps',
+				activeReportingStep: 'next-steps',
 				completedTasks: [ 'not-an-id' ],
 			} as RootState );
 
@@ -176,7 +176,7 @@ describe( '[Bad URL State]', () => {
 				issueType: 'bug',
 				issueTitle: '',
 			},
-			activeReportingStep: 'nextSteps',
+			activeReportingStep: 'next-steps',
 			activePage: 'reportingFlow',
 		} as RootState );
 

--- a/src/url-history/__tests__/parsers.test.ts
+++ b/src/url-history/__tests__/parsers.test.ts
@@ -4,7 +4,7 @@ import { queryToState, stateToQuery } from '../parsers';
 describe( 'url-history-parsers', () => {
 	test( 'Parsing state to query params and back preserves tracked top level state keys', () => {
 		const startingState: RootState = {
-			activePage: 'reportingFlow',
+			activePage: 'report-issue',
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			reportingConfig: { foo: 'bar' } as any,
 			availableRepoFilters: {

--- a/src/url-history/__tests__/parsers.test.ts
+++ b/src/url-history/__tests__/parsers.test.ts
@@ -15,7 +15,7 @@ describe( 'url-history-parsers', () => {
 			issueDetails: {
 				issueType: 'bug',
 				featureId: 'test_feature_id',
-				issueTitle: '',
+				issueTitle: 'fake title',
 			},
 			featureSelectorForm: {
 				searchTerm: 'should be ignored',
@@ -27,8 +27,8 @@ describe( 'url-history-parsers', () => {
 			duplicateSearch: {
 				searchTerm: 'Test search term',
 				activeRepoFilters: [ 'test_repo_1', 'test_repo_2' ],
-				sort: 'relevance',
-				statusFilter: 'all',
+				sort: 'date-created',
+				statusFilter: 'open',
 			},
 			startOverCounter: 0,
 		};

--- a/src/url-history/parsers.ts
+++ b/src/url-history/parsers.ts
@@ -23,10 +23,32 @@ export function stateToQuery( state: RootState ) {
 	for ( const key of trackedStateKeys ) {
 		stateToSerialize[ key ] = state[ key ];
 	}
-	const query = qs.stringify( stateToSerialize );
+	const query = qs.stringify( stateToSerialize, {
+		filter( prefix, value ) {
+			if ( isFalsyOrEmpty( value ) ) {
+				return;
+			}
+
+			if ( defaultStateValues[ prefix ] === value ) {
+				return;
+			}
+
+			return value;
+		},
+	} );
 
 	return query;
 }
+
+function isFalsyOrEmpty( value: unknown ) {
+	return ! value || ( Array.isArray( value ) && value.length === 0 );
+}
+
+const defaultStateValues: { [ key: string ]: string } = {
+	'duplicateSearch[statusFilter]': 'all',
+	'duplicateSearch[sort]': 'relevance',
+	'issueDetails[issueType]': 'unset',
+};
 
 export function queryToState( query: string ): Partial< RootState > {
 	const queryObject = qs.parse( query, {

--- a/src/url-history/parsers.ts
+++ b/src/url-history/parsers.ts
@@ -25,6 +25,11 @@ export function stateToQuery( state: RootState ) {
 		stateToSerialize[ key ] = state[ key ];
 	}
 	const query = qs.stringify( stateToSerialize, {
+		// Dots read WAY nicer for objects. We don't have to encode them!
+		allowDots: true,
+		// To keep the URL clean, we only store relevant state values.
+		// This means we skip anything falsy/empty, and avoid defaults that aren't meaningful.
+		// It is up the reducer to provide defaults and to handle missing values.
 		filter( prefix, value ) {
 			if ( isFalsyOrEmpty( value ) ) {
 				return;
@@ -46,14 +51,16 @@ function isFalsyOrEmpty( value: unknown ) {
 }
 
 const defaultStateValues: { [ key: string ]: string } = {
-	'duplicateSearch[statusFilter]': 'all',
-	'duplicateSearch[sort]': 'relevance',
-	'issueDetails[issueType]': 'unset',
+	'duplicateSearch.statusFilter': 'all',
+	'duplicateSearch.sort': 'relevance',
+	'issueDetails.issueType': 'unset',
 };
 
 export function queryToState( query: string ): Partial< RootState > {
 	const queryObject = qs.parse( query, {
 		ignoreQueryPrefix: true,
+		// Dots read WAY nicer for objects. We don't have to encode them!
+		allowDots: true,
 		// Adding the ability to store and read booleans/nulls/undefineds.
 		// For now, we'll parse numbers as strings. We don't really use numbers in our state.
 		// See discussion here: https://github.com/ljharb/qs/issues/91

--- a/src/url-history/parsers.ts
+++ b/src/url-history/parsers.ts
@@ -7,11 +7,12 @@ import qs from 'qs';
 type KeyableRootState = Omit< RootState, keyof EmptyObject >;
 
 // If you want any redux state to be tracked in the URL, add the top level key here.
+// The order they are in is the order they will appear in the URL
 const trackedStateKeys: ( keyof KeyableRootState )[] = [
 	'activePage',
+	'activeReportingStep',
 	'duplicateSearch',
 	'issueDetails',
-	'activeReportingStep',
 	'completedTasks',
 ];
 


### PR DESCRIPTION
#### What Does This PR Add/Change?

Don't ya just hate when you go to Bugomattic, make one teeny, innocent change, and then get steamrolled by a URL that looks like the green symbols from the Matrix? I sure do!

It's time to make our state-tracking URL more user-friendly!

**Note, these changes are actually quite small. I just updated some static string values, and that corresponded to a lot of file updates!

Here's how our URL is now better:
- We don't track falsy values or empty arrays.
- For more parameter-like state, we don't track the value if it's the default. The notable exception are the `activePage` and the `activeReportingStep`. (These feel more like navigation values, so hiding the default felt weird. Although I feel that way much more so about `activeStep` than `activeReportingStep`. What do you think?)
- For objects, we use "dot" notation instead of brackets. Fullstops don't need to be encoded, so I think this reads wayyyyy nicer.
- I simplified the values for all our pre-defined string types (like `IssueType` and `ActivePage`) and switched from camelCase values to kebab-case values. I think that will be more user-friendly for manual editing!
- I changed the order of the state keys in the URL

#### Testing Instructions

- Unit tests still pass
- Navigate through the app, and see how the URL now looks

Note: the search term appears to be borked, and was so before this change. I've written up the issue in #93 and will fix it in another PR 👍 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #69 