### PR TITLE
Add ability to resize feature tree vertically

### DIFF
--- a/src/feature-selector-form/feature-selector-form.module.css
+++ b/src/feature-selector-form/feature-selector-form.module.css
@@ -9,13 +9,22 @@
 	margin-bottom: 1rem;
 }
 
+.treeFieldset {
+	border: none;
+	padding: 0;
+	margin: 0;
+}
+
 .treeWrapper {
-	height: 320px;
-	overflow-y: scroll;
 	/* This helps preserve the focus outline */
 	padding: 1px;
 	margin: 0;
 	border: none;
+	resize: vertical;
+	/* This helps cut rows in half to show overflow */
+	height: 330px;
+	min-height: 80px;
+	overflow-y: scroll;
 }
 
 .firstLevel {
@@ -130,7 +139,7 @@ button.clearButton:active {
 }
 
 .bottomPanel {
-	margin-top: 1rem;
+	margin-top: 0.25rem;
 	border-top: solid 1px var( --color-border );
 	padding-top: 1.5rem;
 	padding-bottom: 1.5rem;

--- a/src/feature-selector-form/sub-components/feature-selector-tree.tsx
+++ b/src/feature-selector-form/sub-components/feature-selector-tree.tsx
@@ -42,12 +42,14 @@ export function FeatureSelectorTree( { parentElementId }: Props ) {
 	}
 
 	return (
-		<fieldset className={ styles.treeWrapper } id={ parentElementId }>
-			{ searchMessageDisplay }
-			<legend className="screenReaderOnly">
-				Expandable and collapsible tree with products, feature groups, and features
-			</legend>
-			<SortedProductList productIds={ productsToDisplay } />
-		</fieldset>
+		<div className={ styles.treeWrapper }>
+			<fieldset className={ styles.treeFieldset } id={ parentElementId }>
+				{ searchMessageDisplay }
+				<legend className="screenReaderOnly">
+					Expandable and collapsible tree with products, feature groups, and features
+				</legend>
+				<SortedProductList productIds={ productsToDisplay } />
+			</fieldset>
+		</div>
 	);
 }


### PR DESCRIPTION
#### What Does This PR Add/Change?

This make the feature tree vertically resizable! This should help users who want to do manual exploration of the tree.

Along with that, there were a couple of tiny css tweaks:
- Making the starting height 330px -- with our fixed button heights, this tends to cut an overflow button in half, which is nice for showing the fact that the list is scrollable
- I pulled the margin between the scrollable panel and the bottom panel back a bit. It felt weird to have the resize icon "floating" a fell `rem` above the bottom panel

#### Testing Instructions

Play around with it!

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #