### PR TITLE
Code Hygiene: Make standardized button components for shared styling

### DIFF
--- a/src/common/components/buttons.module.css
+++ b/src/common/components/buttons.module.css
@@ -1,0 +1,68 @@
+@import '../../variables.css';
+
+button.button {
+	display: inline-flex;
+	flex-direction: row;
+	align-items: center;
+	border-radius: 2px;
+}
+
+button.primary {
+	color: var( --color-white );
+	background-color: var( --color-primary );
+}
+
+button.primary:hover {
+	background-color: var( --color-primary-dark );
+}
+
+button.primary:active {
+	background-color: var( --color-primary-extra-dark );
+}
+
+button.primary:focus-visible {
+	outline-offset: 2px;
+}
+
+button.text {
+	color: var( --color-primary );
+	background-color: transparent;
+	border: none;
+	padding: 0.25rem 0 0 0;
+}
+
+button.text:hover {
+	color: var( --color-primary-dark );
+}
+
+button.text:active {
+	color: var( --color-primary-extra-dark );
+}
+
+button.clear {
+	color: var( --color-primary );
+	background-color: var( --color-white );
+}
+
+button.outlinePrimary {
+	color: var( --color-primary );
+	background-color: var( --color-white );
+	border: 1px solid var( --color-primary );
+}
+
+button.outlineNeutral {
+	background-color: var( --color-white );
+	border: 1px solid var( --color-border-dark );
+}
+
+button.clear:hover,
+button.outlinePrimary:hover,
+button.outlineNeutral:hover {
+	background-color: var( --color-neutral-extra-light );
+}
+
+button.clear:active,
+button.outlinePrimary:active,
+button.outlineNeutral:active {
+	background-color: var( --color-neutral-light );
+}

--- a/src/common/components/buttons.module.css
+++ b/src/common/components/buttons.module.css
@@ -10,25 +10,33 @@ button.button {
 button.primary {
 	color: var( --color-white );
 	background-color: var( --color-primary );
+	border: 1px solid var( --color-primary );
 }
 
 button.primary:hover {
 	background-color: var( --color-primary-dark );
+	border-color: var( --color-primary-dark );
 }
 
 button.primary:active {
 	background-color: var( --color-primary-extra-dark );
+	border-color: var( --color-primary-extra-dark );
 }
 
 button.primary:focus-visible {
+	outline: 2px solid var( --color-primary );
 	outline-offset: 2px;
+}
+
+button.primary svg path {
+	fill: var( --color-white );
 }
 
 button.text {
 	color: var( --color-primary );
 	background-color: transparent;
 	border: none;
-	padding: 0.25rem 0 0 0;
+	padding: 0;
 }
 
 button.text:hover {
@@ -42,12 +50,18 @@ button.text:active {
 button.clear {
 	color: var( --color-primary );
 	background-color: var( --color-white );
+	border: 1px solid transparent;
 }
 
 button.outlinePrimary {
 	color: var( --color-primary );
 	background-color: var( --color-white );
 	border: 1px solid var( --color-primary );
+}
+
+button.clear svg path,
+button.outlinePrimary svg path {
+	fill: var( --color-primary );
 }
 
 button.outlineNeutral {
@@ -65,4 +79,11 @@ button.clear:active,
 button.outlinePrimary:active,
 button.outlineNeutral:active {
 	background-color: var( --color-neutral-light );
+}
+
+button.clear:focus-visible,
+button.outlinePrimary:focus-visible,
+button.outlineNeutral:focus-visible {
+	border-color: var( --color-primary );
+	outline: 1px solid var( --color-primary );
 }

--- a/src/common/components/buttons.module.css
+++ b/src/common/components/buttons.module.css
@@ -49,7 +49,7 @@ button.text:active {
 
 button.clear {
 	color: var( --color-primary );
-	background-color: var( --color-white );
+	background-color: transparent;
 	border: 1px solid transparent;
 }
 

--- a/src/common/components/buttons.tsx
+++ b/src/common/components/buttons.tsx
@@ -11,15 +11,16 @@ export const OutlinePrimaryButton = createButton( styles.outlinePrimary );
 
 export const OutlineNeutralButton = createButton( styles.outlineNeutral );
 
-function createButton( buttonStlyeClass: string ) {
+function createButton( buttonStyleClass: string ) {
 	return forwardRef< HTMLButtonElement, ButtonHTMLAttributes< HTMLButtonElement > >(
 		function Button( { className, children, ...props }, ref ) {
+			const classes = [ styles.button, buttonStyleClass ];
+			if ( className ) {
+				classes.push( className );
+			}
+
 			return (
-				<button
-					className={ `${ styles.button } ${ buttonStlyeClass } ${ className }` }
-					ref={ ref }
-					{ ...props }
-				>
+				<button className={ classes.join( ' ' ) } ref={ ref } { ...props }>
 					{ children }
 				</button>
 			);

--- a/src/common/components/buttons.tsx
+++ b/src/common/components/buttons.tsx
@@ -7,6 +7,10 @@ export const ClearButton = createButton( styles.clear );
 
 export const TextButton = createButton( styles.text );
 
+export const OutlinePrimaryButton = createButton( styles.outlinePrimary );
+
+export const OutlineNeutralButton = createButton( styles.outlineNeutral );
+
 function createButton( buttonStlyeClass: string ) {
 	return forwardRef< HTMLButtonElement, ButtonHTMLAttributes< HTMLButtonElement > >(
 		function Button( { className, children, ...props }, ref ) {

--- a/src/common/components/buttons.tsx
+++ b/src/common/components/buttons.tsx
@@ -1,0 +1,24 @@
+import React, { ButtonHTMLAttributes, forwardRef } from 'react';
+import styles from './buttons.module.css';
+
+export const PrimaryButton = createButton( styles.primary );
+
+export const ClearButton = createButton( styles.clear );
+
+export const TextButton = createButton( styles.text );
+
+function createButton( buttonStlyeClass: string ) {
+	return forwardRef< HTMLButtonElement, ButtonHTMLAttributes< HTMLButtonElement > >(
+		function Button( { className, children, ...props }, ref ) {
+			return (
+				<button
+					className={ `${ styles.button } ${ buttonStlyeClass } ${ className }` }
+					ref={ ref }
+					{ ...props }
+				>
+					{ children }
+				</button>
+			);
+		}
+	);
+}

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -9,3 +9,4 @@ export * from './segmented-control';
 export * from './dropdown';
 export * from './banner';
 export * from './step-subheader';
+export * from './buttons';

--- a/src/duplicate-results/duplicate-results.module.css
+++ b/src/duplicate-results/duplicate-results.module.css
@@ -167,21 +167,7 @@ p.placeholderText {
 }
 
 button.bannerButton {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	color: var( --color-primary );
-	background-color: var( --color-white );
-	border: 1px solid var( --color-primary );
 	padding: 0.625rem;
-}
-
-button.bannerButton:hover {
-	background-color: var( --color-neutral-extra-light );
-}
-
-button.bannerButton:active {
-	background-color: var( --color-neutral-light );
 }
 
 .bannerSimpleButtonText {
@@ -191,10 +177,6 @@ button.bannerButton:active {
 .bannerButtonIcon {
 	height: 1.5rem;
 	width: 1.5rem;
-}
-
-.bannerButtonIcon path {
-	fill: var( --color-primary );
 }
 
 @media only screen and ( max-width: 600px ) {

--- a/src/duplicate-results/sub-components/report-issue-banner.tsx
+++ b/src/duplicate-results/sub-components/report-issue-banner.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { ReactComponent as MegaphoneIllustration } from '../svgs/megaphone.svg';
-import { Banner } from '../../common/components';
+import { Banner, OutlinePrimaryButton } from '../../common/components';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { ReportIssueDropdownMenu } from '../../common/components/report-issue-dropdown-menu';
 import { selectIssueType } from '../../issue-details/issue-details-slice';
@@ -21,19 +21,19 @@ export function ReportIssueBanner() {
 	}, [ dispatch ] );
 
 	const simpleButton = (
-		<button className={ styles.bannerButton } onClick={ handleSimpleButtonClick }>
+		<OutlinePrimaryButton className={ styles.bannerButton } onClick={ handleSimpleButtonClick }>
 			<span className={ styles.bannerSimpleButtonText }>Report an Issue</span>
 			<RightArrowIcon aria-hidden="true" className={ styles.bannerButtonIcon } />
-		</button>
+		</OutlinePrimaryButton>
 	);
 
 	const buttonWithDropdown = (
 		<ReportIssueDropdownMenu>
-			<button className={ styles.bannerButton }>
+			<OutlinePrimaryButton className={ styles.bannerButton }>
 				<PlusIcon aria-hidden="true" className={ styles.bannerButtonIcon } />
 				<span>Report an Issue</span>
 				<DownChevronIcon aria-hidden="true" className={ styles.bannerButtonIcon } />
-			</button>
+			</OutlinePrimaryButton>
 		</ReportIssueDropdownMenu>
 	);
 

--- a/src/duplicate-search/duplicate-search-controls.module.css
+++ b/src/duplicate-search/duplicate-search-controls.module.css
@@ -33,11 +33,6 @@ button.dropdownButton {
 	padding: 0.375rem 0.5625rem 0.375rem 0.5625rem;
 }
 
-button.dropdownButton[data-active='true'] {
-	/* Primary buttons don't traditionally have any border, so for size consistency, adding one here */
-	border: 1px solid var( --color-primary );
-}
-
 .repoPopover {
 	z-index: 2;
 	background-color: var( --color-white );

--- a/src/duplicate-search/duplicate-search-controls.module.css
+++ b/src/duplicate-search/duplicate-search-controls.module.css
@@ -29,47 +29,13 @@
 	align-items: center;
 }
 
-/* TODO: Move to its own app-wide styles in CSS or through a shared component */
 button.dropdownButton {
 	padding: 0.375rem 0.5625rem 0.375rem 0.5625rem;
-	display: flex;
-	align-items: center;
-	background-color: var( --color-white );
-	border-radius: 2px;
-	border: 1px solid var( --color-border-dark );
-}
-
-button.dropdownButton:hover {
-	background-color: var( --color-neutral-extra-light );
-}
-
-button.dropdownButton:active {
-	background-color: var( --color-neutral-light );
-}
-
-button.dropdownButton:focus-visible {
-	border-color: var( --color-primary );
-	outline: 1px solid var( --color-primary );
 }
 
 button.dropdownButton[data-active='true'] {
-	background-color: var( --color-primary );
-	border-color: var( --color-primary );
-	color: var( --color-white );
-}
-
-button.dropdownButton[data-active='true'] .inlineIcon path {
-	fill: var( --color-white );
-}
-
-button.dropdownButton[data-active='true']:hover {
-	background-color: var( --color-primary-dark );
-	border-color: var( --color-primary-dark );
-}
-
-button.dropdownButton[data-active='true']:active {
-	background-color: var( --color-primary-extra-dark );
-	border-color: var( --color-primary-extra-dark );
+	/* Primary buttons don't traditionally have any border, so for size consistency, adding one here */
+	border: 1px solid var( --color-primary );
 }
 
 .repoPopover {
@@ -137,20 +103,6 @@ button.dropdownButton[data-active='true']:active {
 	margin: 1rem auto 1rem auto;
 }
 
-/* TODO: Move to its own app-wide styles in CSS or through a shared component */
-.repoFilterCancelButton {
-	color: var( --color-primary );
-	background-color: var( --color-white );
-}
-
-.repoFilterCancelButton:hover {
-	background-color: var( --color-neutral-extra-light );
-}
-
-.repoFilterCancelButton:active {
-	background-color: var( --color-neutral-light );
-}
-
 .repoFilterOrgList {
 	list-style: none;
 	padding-left: 0;
@@ -181,20 +133,6 @@ button.dropdownButton[data-active='true']:active {
 	display: flex;
 	align-items: center;
 	width: max-content;
-}
-
-button.repoFilterMassActionButton {
-	color: var( --color-primary );
-	background-color: transparent;
-	padding: 0;
-}
-
-.repoFilterMassActionButton:hover {
-	color: var( --color-primary-dark );
-}
-
-.repoFilterMassActionButton:active {
-	color: var( --color-primary-extra-dark );
 }
 
 .sortOption {

--- a/src/duplicate-search/sub-components/manual-repo-filter.tsx
+++ b/src/duplicate-search/sub-components/manual-repo-filter.tsx
@@ -8,6 +8,7 @@ import {
 import { useMonitoring } from '../../monitoring/monitoring-provider';
 import { useLoggerWithCache } from '../../monitoring/use-logger-with-cache';
 import { ActiveRepos } from './types';
+import { TextButton } from '../../common/components';
 
 interface Props {
 	activeRepos: ActiveRepos;
@@ -48,9 +49,7 @@ export function ManualRepoFilter( { activeRepos, setActiveRepos }: Props ) {
 		};
 
 	const selectAllButton = (
-		<button
-			type="button"
-			className={ styles.repoFilterMassActionButton }
+		<TextButton
 			onClick={ () =>
 				setActiveRepos(
 					availableRepos.reduce( ( newActiveRepos: ActiveRepos, repo: string ) => {
@@ -61,17 +60,13 @@ export function ManualRepoFilter( { activeRepos, setActiveRepos }: Props ) {
 			}
 		>
 			Select all
-		</button>
+		</TextButton>
 	);
 
 	const deselectAllButton = (
-		<button
-			type="button"
-			className={ styles.repoFilterMassActionButton }
-			onClick={ () => setActiveRepos( {} ) }
-		>
+		<TextButton type="button" onClick={ () => setActiveRepos( {} ) }>
 			Deselect all
-		</button>
+		</TextButton>
 	);
 
 	const massActionButton =

--- a/src/duplicate-search/sub-components/repo-filter.tsx
+++ b/src/duplicate-search/sub-components/repo-filter.tsx
@@ -12,7 +12,12 @@ import {
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import styles from '../duplicate-search-controls.module.css';
 import { selectActiveRepoFilters, setActiveRepoFilters } from '../duplicate-search-slice';
-import { ClearButton, PrimaryButton, SegmentedControl } from '../../common/components';
+import {
+	ClearButton,
+	OutlineNeutralButton,
+	PrimaryButton,
+	SegmentedControl,
+} from '../../common/components';
 import { DefaultRepoFilter } from './default-repo-filter';
 import { ManualRepoFilter } from './manual-repo-filter';
 import { ReactComponent as DownIcon } from '../../common/svgs/chevron-down.svg';
@@ -89,6 +94,9 @@ export function RepoFilter() {
 		setFilterMode( newFilterMode as FilterMode );
 	}, [] );
 
+	const repoFiltersAreActive = savedActiveRepos.length > 0;
+	const TriggerButtonComponent = repoFiltersAreActive ? PrimaryButton : OutlineNeutralButton;
+
 	const popoverBodyClasses = [ styles.repoPopoverBody ];
 	if ( filterMode === 'Manual' ) {
 		popoverBodyClasses.push( styles.repoPopoverManualModeBody );
@@ -102,7 +110,7 @@ export function RepoFilter() {
 
 	return (
 		<>
-			<button
+			<TriggerButtonComponent
 				className={ styles.dropdownButton }
 				ref={ refs.setReference }
 				{ ...getReferenceProps() }
@@ -113,7 +121,7 @@ export function RepoFilter() {
 				<FilterIcon aria-hidden={ true } className={ styles.inlineIcon } />
 				<span>Repositories</span>
 				<DownIcon aria-hidden={ true } className={ styles.inlineIcon } />
-			</button>
+			</TriggerButtonComponent>
 			<span hidden id={ currentFilterDescriptionId }>
 				{ currentFilterDescription }
 			</span>

--- a/src/duplicate-search/sub-components/repo-filter.tsx
+++ b/src/duplicate-search/sub-components/repo-filter.tsx
@@ -12,7 +12,7 @@ import {
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import styles from '../duplicate-search-controls.module.css';
 import { selectActiveRepoFilters, setActiveRepoFilters } from '../duplicate-search-slice';
-import { SegmentedControl } from '../../common/components';
+import { ClearButton, PrimaryButton, SegmentedControl } from '../../common/components';
 import { DefaultRepoFilter } from './default-repo-filter';
 import { ManualRepoFilter } from './manual-repo-filter';
 import { ReactComponent as DownIcon } from '../../common/svgs/chevron-down.svg';
@@ -143,16 +143,8 @@ export function RepoFilter() {
 						<div className={ popoverBodyClasses.join( ' ' ) }>{ filterModeDisplay }</div>
 						<div className={ styles.repoPopoverFooter }>
 							<div className={ styles.repoFilterButtonWrapper }>
-								<button
-									type="button"
-									className={ styles.repoFilterCancelButton }
-									onClick={ handleCancelClick }
-								>
-									Cancel
-								</button>
-								<button type="button" className="primaryButton" onClick={ handleFilterClick }>
-									Filter
-								</button>
+								<ClearButton onClick={ handleCancelClick }>Cancel</ClearButton>
+								<PrimaryButton onClick={ handleFilterClick }>Filter</PrimaryButton>
 							</div>
 						</div>
 					</div>

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from '../../common/components';
+import {
+	Dropdown,
+	DropdownContent,
+	DropdownItem,
+	DropdownTrigger,
+	OutlineNeutralButton,
+} from '../../common/components';
 import styles from '../duplicate-search-controls.module.css';
 import { IssueSortOption } from '../types';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
@@ -57,11 +63,11 @@ export function SortSelect() {
 	return (
 		<Dropdown placement={ placement } role="listbox">
 			<DropdownTrigger aria-label="Sort results by…">
-				<button className={ styles.dropdownButton }>
+				<OutlineNeutralButton className={ styles.dropdownButton }>
 					<SortIcon aria-hidden={ true } className={ styles.inlineIcon } />
 					<span>{ sortDropdownTriggerLabel }</span>
 					<DownIcon aria-hidden={ true } className={ styles.inlineIcon } />
-				</button>
+				</OutlineNeutralButton>
 			</DropdownTrigger>
 			<DropdownContent aria-label="Sort options">
 				{ sortOptions.map( ( sortOption ) => (

--- a/src/feature-selector-form/feature-selector-form.module.css
+++ b/src/feature-selector-form/feature-selector-form.module.css
@@ -101,18 +101,6 @@ button.treeNode[aria-selected='true']:hover {
 	margin-right: 0.5rem;
 }
 
-button.clearButton {
-	color: var( --color-primary );
-	background-color: transparent;
-	border: none;
-	padding: 0.25rem 0 0 0;
-}
-
-button.clearButton:hover,
-button.clearButton:active {
-	color: var( --color-primary-dark );
-}
-
 .selectedFeatureRepositories,
 .selectedFeatureKeywords {
 	margin-top: 1.25rem;

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -1,6 +1,11 @@
 import React, { FormEventHandler, ReactNode, useCallback, useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
-import { DebouncedSearch, FormErrorMessage, StepSubheader } from '../common/components';
+import {
+	DebouncedSearch,
+	FormErrorMessage,
+	PrimaryButton,
+	StepSubheader,
+} from '../common/components';
 import { selectIssueFeatureId, setIssueFeatureId } from '../issue-details/issue-details-slice';
 import { useMonitoring } from '../monitoring/monitoring-provider';
 import {
@@ -115,7 +120,7 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 						{ bottomPanelDisplay }
 					</section>
 					<div className={ styles.continueButtonWrapper }>
-						<button className="primaryButton">Continue</button>
+						<PrimaryButton>Continue</PrimaryButton>
 					</div>
 				</div>
 			</form>

--- a/src/feature-selector-form/sub-components/selected-feature-details.tsx
+++ b/src/feature-selector-form/sub-components/selected-feature-details.tsx
@@ -7,6 +7,7 @@ import { useMonitoring } from '../../monitoring/monitoring-provider';
 import { SortedKeywordList } from './sorted-keyword-list';
 import { selectReposForFeature } from '../../combined-selectors/relevant-task-ids';
 import { SearchHighlighter } from './search-hightlighter';
+import { TextButton } from '../../common/components';
 
 export function SelectedFeatureDetails() {
 	const dispatch = useAppDispatch();
@@ -61,14 +62,13 @@ export function SelectedFeatureDetails() {
 			<h3 className="screenReaderOnly">Currently selected feature:</h3>
 			<div>
 				<span className={ styles.selectedFeatureName }>{ featureName }</span>
-				<button
+				<TextButton
 					type="button"
-					className={ styles.clearButton }
 					aria-label="Clear currently selected feature"
 					onClick={ handleClearClick }
 				>
 					Clear
-				</button>
+				</TextButton>
 			</div>
 			{ description && (
 				<p

--- a/src/index.css
+++ b/src/index.css
@@ -84,29 +84,6 @@ body {
 	outline: revert;
 }
 
-/*
-These are generic enough that it feels like overkill to make a new component just for these button styles.
-So, we'll enable a global class option. 
-*/
-
-.root button.primaryButton {
-	color: var( --color-white );
-	background-color: var( --color-primary );
-	border-radius: 2px;
-}
-
-.root button.primaryButton:hover {
-	background-color: var( --color-primary-dark );
-}
-
-.root button.primaryButton:active {
-	background-color: var( --color-primary-extra-dark );
-}
-
-.root button.primaryButton:focus-visible {
-	outline-offset: 2px;
-}
-
 .root input code {
 	font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/src/reporting-flow-page/reporting-flow-page.module.css
+++ b/src/reporting-flow-page/reporting-flow-page.module.css
@@ -65,17 +65,6 @@
 	position: relative;
 }
 
-button.editButton {
-	color: var( --color-primary );
-	background-color: transparent;
-	padding: 0;
-}
-
-button.editButton:hover,
-button.editButton:active {
-	color: var( --color-primary-dark );
-}
-
 .completedContentHeader {
 	font-size: var( --font-body );
 	font-weight: 400;

--- a/src/reporting-flow-page/sub-components/next-steps-step.tsx
+++ b/src/reporting-flow-page/sub-components/next-steps-step.tsx
@@ -13,6 +13,7 @@ import { useMonitoring } from '../../monitoring/monitoring-provider';
 import { useLoggerWithCache } from '../../monitoring/use-logger-with-cache';
 import { MoreInfo } from '../../next-steps/more-info';
 import { updateHistoryWithState } from '../../url-history/actions';
+import { PrimaryButton } from '../../common/components';
 
 interface Props {
 	stepNumber: number;
@@ -75,6 +76,7 @@ function MissingRequiredInfoWarning() {
 	const dispatch = useAppDispatch();
 	const handleStartOverClick = () => {
 		dispatch( startOver() );
+		// We stay on the same page, just restarting the reporting flow!
 		dispatch( updateHistoryWithState() );
 	};
 	return (
@@ -85,12 +87,9 @@ function MissingRequiredInfoWarning() {
 				This almost always means we could not parse the info in the URL. Please start over by
 				clicking the button below.
 			</p>
-			<button
-				onClick={ handleStartOverClick }
-				className={ `${ styles.startOverButton } primaryButton` }
-			>
+			<PrimaryButton onClick={ handleStartOverClick } className={ styles.startOverButton }>
 				Start Over
-			</button>
+			</PrimaryButton>
 		</div>
 	);
 }

--- a/src/reporting-flow-page/sub-components/step-container.tsx
+++ b/src/reporting-flow-page/sub-components/step-container.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import styles from '../reporting-flow-page.module.css';
+import { TextButton } from '../../common/components';
 
 interface Props {
 	onEdit: () => void;
@@ -43,9 +44,9 @@ export function StepContainer( {
 					<span className={ styles.stepHeaderTitle }>{ title }</span>
 				</h3>
 				{ showEditButton && (
-					<button className={ styles.editButton } onClick={ onEdit } aria-describedby={ headerId }>
+					<TextButton onClick={ onEdit } aria-describedby={ headerId }>
 						Edit
-					</button>
+					</TextButton>
 				) }
 			</div>
 			{ children && <div className={ styles.stepContent }>{ children }</div> }

--- a/src/start-over/start-over-banner.module.css
+++ b/src/start-over/start-over-banner.module.css
@@ -14,28 +14,10 @@ button.menuItem {
 }
 
 button.triggerButton {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	color: var( --color-primary );
-	background-color: var( --color-white );
-	border: 1px solid var( --color-primary );
 	padding: 0.625rem 0.625rem 0.625rem 1rem;
-}
-
-button.triggerButton:hover {
-	background-color: var( --color-neutral-extra-light );
-}
-
-button.triggerButton:active {
-	background-color: var( --color-neutral-light );
 }
 
 .triggerButtonIcon {
 	height: 1.5rem;
 	width: 1.5rem;
-}
-
-.triggerButtonIcon path {
-	fill: var( --color-primary );
 }

--- a/src/start-over/start-over-banner.tsx
+++ b/src/start-over/start-over-banner.tsx
@@ -11,6 +11,7 @@ import {
 	DropdownContent,
 	DropdownItem,
 	DropdownTrigger,
+	OutlinePrimaryButton,
 } from '../common/components';
 import { ReactComponent as ChecklistIllustration } from './checklist-illustration.svg';
 import { ActivePage } from '../active-page/types';
@@ -82,10 +83,10 @@ function StartOverDropdownMenu() {
 	return (
 		<Dropdown role="menu" placement="bottom">
 			<DropdownTrigger>
-				<button className={ styles.triggerButton }>
+				<OutlinePrimaryButton className={ styles.triggerButton }>
 					<span>Start Over</span>
 					<DownChevronIcon aria-hidden="true" className={ styles.triggerButtonIcon } />
-				</button>
+				</OutlinePrimaryButton>
 			</DropdownTrigger>
 			<DropdownContent>
 				{ menuOptions.map( ( { targetActivePage, label, icon: Icon } ) => (

--- a/src/type-form/type-form.tsx
+++ b/src/type-form/type-form.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEventHandler, FormEventHandler, ReactNode, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
-import { FormErrorMessage, StepSubheader } from '../common/components';
+import { FormErrorMessage, PrimaryButton, StepSubheader } from '../common/components';
 import { selectIssueDetails, setIssueType } from '../issue-details/issue-details-slice';
 import { IssueType } from '../issue-details/types';
 import { ReactComponent as InfoIcon } from '../common/svgs/info.svg';
@@ -139,7 +139,7 @@ export function TypeForm( { onContinue }: Props ) {
 			</fieldset>
 
 			<div className={ styles.continueWrapper }>
-				<button className="primaryButton">Continue</button>
+				<PrimaryButton>Continue</PrimaryButton>
 			</div>
 		</form>
 	);


### PR DESCRIPTION
#### What Does This PR Add/Change?

As I was told growing up in my American Midwest home: "the buttons that style together, stay together". 😆 

Our button styling had gotten away from us a bit! In our design, we have a shared set of a few different button styles. This PR standardizes those into a shared set of components that are then re-used throughout the app! Now the majority of the button code (css included) is all in one place! Yum! 😋 

Here's how the styling order goes...
1. In `index.css`, we target all `button` elements in the app, mostly resetting a bunch of settings to their initial styles. This is mostly to mitigate some CSS collisions when deployed internally at a8c. We also set some helpful starting points for all buttons in the site (even ones that aren't "action" buttons), like the font and a basic padding, etc.
2. In the `buttons.module.css`, we set the styles for our shared set of component buttons.
3. Other consuming components can still provide other classes to these button components to override some styles in unique cases. This almost always is just massaging `padding` -- we make certain buttons bigger or smaller in various places in the app!

What is left out?
- Buttons that are part of other controls, like the popover menu, the navbar, and the segmented control.
- The CTA links in the Next Steps. Since these are links and not true buttons, and because we treat the styling a little different for them, they seemed best left on their own.

#### Testing Instructions

The unit tests still pass, but that's not too surprising...

Mostly, go through the app and make sure all the buttons still look as they should! I've done a couple passes in this regard, but always appreciate the extra eyes 😄 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #74 
