### PR TITLE
Update label from 'Date added' to 'Date created'

### DIFF
--- a/src/duplicate-search/__tests__/duplicate-search-controls.test.tsx
+++ b/src/duplicate-search/__tests__/duplicate-search-controls.test.tsx
@@ -440,7 +440,7 @@ describe( '[DuplicateSearchControls]', () => {
 
 			expect( screen.getByRole( 'listbox', { name: 'Sort options' } ) ).toBeInTheDocument();
 
-			const expectedSortOptions = [ 'Relevance', 'Date added' ];
+			const expectedSortOptions = [ 'Relevance', 'Date created' ];
 			for ( const expectedSortOption of expectedSortOptions ) {
 				expect( screen.getByRole( 'option', { name: expectedSortOption } ) ).toBeInTheDocument();
 			}
@@ -452,7 +452,7 @@ describe( '[DuplicateSearchControls]', () => {
 			} );
 
 			await user.click( screen.getByRole( 'combobox', { name: 'Sort results by…' } ) );
-			await user.click( screen.getByRole( 'option', { name: 'Date added' } ) );
+			await user.click( screen.getByRole( 'option', { name: 'Date created' } ) );
 
 			expect( screen.queryByRole( 'listbox', { name: 'Sort options' } ) ).not.toBeInTheDocument();
 			expect( apiClient.searchIssues ).toHaveBeenCalledWith(
@@ -462,7 +462,7 @@ describe( '[DuplicateSearchControls]', () => {
 				} )
 			);
 			expect( screen.getByRole( 'combobox', { name: 'Sort results by…' } ) ).toHaveTextContent(
-				'Date added'
+				'Date created'
 			);
 		} );
 
@@ -474,7 +474,7 @@ describe( '[DuplicateSearchControls]', () => {
 			await user.click( screen.getByRole( 'combobox', { name: 'Sort results by…' } ) );
 
 			expect(
-				screen.getByRole( 'option', { name: 'Date added', selected: true } )
+				screen.getByRole( 'option', { name: 'Date created', selected: true } )
 			).toBeInTheDocument();
 		} );
 
@@ -493,7 +493,7 @@ describe( '[DuplicateSearchControls]', () => {
 			await user.keyboard( '{arrowdown}' );
 			await waitFor( () =>
 				expect(
-					screen.getByRole( 'option', { name: 'Date added', selected: false } )
+					screen.getByRole( 'option', { name: 'Date created', selected: false } )
 				).toHaveFocus()
 			);
 		} );
@@ -509,7 +509,7 @@ describe( '[DuplicateSearchControls]', () => {
 			await user.keyboard( 'd' );
 			await waitFor( () =>
 				expect(
-					screen.getByRole( 'option', { name: 'Date added', selected: false } )
+					screen.getByRole( 'option', { name: 'Date created', selected: false } )
 				).toHaveFocus()
 			);
 		} );

--- a/src/duplicate-search/sub-components/sort-select.tsx
+++ b/src/duplicate-search/sub-components/sort-select.tsx
@@ -30,7 +30,7 @@ export function SortSelect() {
 			value: 'relevance',
 		},
 		{
-			label: 'Date added',
+			label: 'Date created',
 			value: 'date-created',
 		},
 	];

--- a/src/url-history/__tests__/history-updates.test.tsx
+++ b/src/url-history/__tests__/history-updates.test.tsx
@@ -129,7 +129,7 @@ describe( 'history updates', () => {
 			activeRepoFilters.length > 0 ? 'true' : 'false'
 		);
 
-		const expectedSortText = sort === 'relevance' ? 'Relevance' : 'Date added';
+		const expectedSortText = sort === 'relevance' ? 'Relevance' : 'Date created';
 		expect( screen.getByRole( 'combobox', { name: 'Sort results by…' } ) ).toHaveTextContent(
 			expectedSortText
 		);
@@ -173,7 +173,7 @@ describe( 'history updates', () => {
 
 		onSortChange: async () => {
 			await user.click( screen.getByRole( 'combobox', { name: 'Sort results by…' } ) );
-			await user.click( screen.getByRole( 'option', { name: 'Date added' } ) );
+			await user.click( screen.getByRole( 'option', { name: 'Date created' } ) );
 		},
 
 		onReportingFlowStart: async () => {


### PR DESCRIPTION
#### What Does This PR Add/Change?

* Updates the label from `Date added` to `Date created` for consistency. 
* Context: https://github.com/Automattic/bugomattic/pull/108#discussion_r1207346059
![Screenshot 2023-05-29 at 08 38 41](https://github.com/Automattic/bugomattic/assets/67279475/0e74d145-a73d-4c3e-a32b-77babfcc649c)

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

1. Click on the sort option 
2. Verify that the label displayed is `Date created` 
3. Check the query string also and make sure that the URL still contains `&duplicateSearch.sort=date-created`

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #