### PR TITLE
Use 'Created'  in issue result

### DIFF
--- a/src/duplicate-results/__tests__/issue-list.test.tsx
+++ b/src/duplicate-results/__tests__/issue-list.test.tsx
@@ -46,7 +46,7 @@ describe( '[IssueList]', () => {
 		render( <IssueList issues={ [ mockIssue ] } /> );
 		expect( screen.getByText( mockIssue.author ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Testrepo' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Opened 3 months ago' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Created 3 months ago' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Updated 2 days ago' ) ).toBeInTheDocument();
 	} );
 

--- a/src/duplicate-results/sub-components/issue-result.tsx
+++ b/src/duplicate-results/sub-components/issue-result.tsx
@@ -26,7 +26,7 @@ export function IssueResult( { issue }: Props ) {
 
 	const now = new Date();
 
-	const dateCreatedDisplay = `Opened ${ formatDistance( new Date( dateCreated ), now, {
+	const dateCreatedDisplay = `Created ${ formatDistance( new Date( dateCreated ), now, {
 		addSuffix: true,
 	} ) }`;
 	const dateCreatedTooltip = format( new Date( dateCreated ), 'PPpppp' );


### PR DESCRIPTION
#### What Does This PR Add/Change?

Related to #110 and follow-up from #108

With the changes on the label from 'Date added' to 'Date created' in #110, we also need to update the text in the issue results! 

Now the copy should be consistent across the app! The text for the date created display should now use `Created`

![Screenshot 2023-06-02 at 09 37 16](https://github.com/Automattic/bugomattic/assets/67279475/1d2f782c-b6c3-471a-94a0-bcba8bc6491f)


#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

1. Search for any issue 
2. Verify that the result says `Created x days ago` or `Created x months ago`


#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #