### PR TITLE
Tune up description searching match criteria

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"react-redux": "^8.0.4",
 		"react-scripts": "5.0.1",
 		"react-tooltip": "^5.8.3",
+		"stopword": "^2.0.8",
 		"url-join": "^5.0.0",
 		"web-vitals": "^2.1.0"
 	},
@@ -85,6 +86,7 @@
 		"@types/jest": "^29.1.2",
 		"@types/lodash.words": "^4.2.7",
 		"@types/path-browserify": "^1.0.0",
+		"@types/stopword": "^2.0.0",
 		"@typescript-eslint/eslint-plugin": "^5.0.0",
 		"@typescript-eslint/parser": "^5.40.0",
 		"eslint": "^8.0.1",

--- a/src/combined-selectors/reporting-config-search-results.ts
+++ b/src/combined-selectors/reporting-config-search-results.ts
@@ -145,25 +145,28 @@ class ReportingConfigSearcher {
 			}
 		}
 
-		const scoreThreshold = 1;
 		const descriptionMatch: () => DescriptionMatch = () => ( {
 			matchType: 'description',
 		} );
 
+		const scoreRatioThreshold = 0.6;
+		const isAboveThreshold = ( score: number ) =>
+			score / searchTermTokens.length >= scoreRatioThreshold;
+
 		for ( const entityId in scores.product ) {
-			if ( scores.product[ entityId ] >= scoreThreshold ) {
+			if ( isAboveThreshold( scores.product[ entityId ] ) ) {
 				this.updateMatchEntity( 'products', entityId, descriptionMatch() );
 			}
 		}
 
 		for ( const entityId in scores.featureGroup ) {
-			if ( scores.featureGroup[ entityId ] >= scoreThreshold ) {
+			if ( isAboveThreshold( scores.featureGroup[ entityId ] ) ) {
 				this.addFeatureGroupAndParents( entityId, descriptionMatch() );
 			}
 		}
 
 		for ( const entityId in scores.feature ) {
-			if ( scores.feature[ entityId ] >= scoreThreshold ) {
+			if ( isAboveThreshold( scores.feature[ entityId ] ) ) {
 				this.addFeatureAndParents( entityId, descriptionMatch() );
 			}
 		}

--- a/src/common/lib/string-utils.ts
+++ b/src/common/lib/string-utils.ts
@@ -1,4 +1,5 @@
 import words from 'lodash.words';
+import { removeStopwords } from 'stopword';
 
 export function includesIgnoringCase( string: string, substring: string ): boolean {
 	return string.toUpperCase().includes( substring.toUpperCase() );
@@ -9,12 +10,9 @@ export function replaceSpaces( string: string, replacementCharacter = '_' ): str
 }
 
 export function tokenizeAndNormalize( string: string ) {
-	// Add more stop words as needed
-	const stopWords = new Set( [ 'a', 'an', 'and', 'the', 'in', 'on', 'at', 'of', 'this', 'to' ] );
-
-	// The lodash 'words' function does a really nice job just as is!
+	// The lodash 'words' function does a really nice job just as is for word splitting!
 	const allWords = words( string.toLowerCase() );
-	return allWords.filter( ( word ) => ! stopWords.has( word ) );
+	return removeStopwords( allWords );
 }
 
 export function escapeStringForRegex( string: string ) {

--- a/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
@@ -91,6 +91,7 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 		backup: [ { type: 'featureGroup', id: 'DEF', weight: 1 } ],
 		blog: [ { type: 'feature', id: 'STU', weight: 1 } ],
 		carousel: [ { type: 'feature', id: 'STU', weight: 1 } ],
+		newspack: [ { type: 'feature', id: 'STU', weight: 1 } ],
 		posts: [ { type: 'feature', id: 'STU', weight: 1 } ],
 		site: [ { type: 'featureGroup', id: 'DEF', weight: 1 } ],
 		traffic: [ { type: 'product', id: 'ABC', weight: 1 } ],
@@ -358,6 +359,18 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 
 			expect( screen.getByRole( 'option', { name: 'GHI Feature' } ) ).toBeInTheDocument();
 			expect( screen.queryByRole( 'option', { name: 'JKL Feature' } ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'Description search matches must match at least 60% of the search term tokens', async () => {
+			const { user } = setup( <FeatureSelectorForm /> );
+
+			await search( user, 'blog carousel newspack foo bar' );
+			expect( screen.getByRole( 'option', { name: /STU Feature/ } ) ).toBeInTheDocument();
+
+			await search( user, 'blog carousel newspack foo bar baz' );
+			expect(
+				screen.getByText( 'No results found. Try a different search or explore manually below.' )
+			).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3027,6 +3027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/stopword@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@types/stopword@npm:2.0.0"
+  checksum: 20fdb908d2f18648a85d6280666b663d50bcd5724db3f10a354263c5ec163dc166fee27fa33e4cf55a3c89a606b52218c54c997c2fa4b5eb85e3e571ca304015
+  languageName: node
+  linkType: hard
+
 "@types/testing-library__jest-dom@npm:^5.9.1":
   version: 5.14.5
   resolution: "@types/testing-library__jest-dom@npm:5.14.5"
@@ -4252,6 +4259,7 @@ __metadata:
     "@types/path-browserify": ^1.0.0
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
+    "@types/stopword": ^2.0.0
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.40.0
     date-fns: ^2.29.3
@@ -4283,6 +4291,7 @@ __metadata:
     react-redux: ^8.0.4
     react-scripts: 5.0.1
     react-tooltip: ^5.8.3
+    stopword: ^2.0.8
     typescript: ^4.8.4
     url-join: ^5.0.0
     web-vitals: ^2.1.0
@@ -13711,6 +13720,13 @@ __metadata:
   dependencies:
     internal-slot: ^1.0.4
   checksum: d04173690b2efa40e24ab70e5e51a3ff31d56d699550cfad084104ab3381390daccb36652b25755e420245f3b0737de66c1879eaa2a8d4fc0a78f9bf892fcb42
+  languageName: node
+  linkType: hard
+
+"stopword@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "stopword@npm:2.0.8"
+  checksum: 1b92d9b317a9b74b6fd92681a9767478c8f8fd856b869f8705afdcf1fd7e28f88062c97a4432c8d9b7a1e9d5491f24405c4815da6fdca887b58b20f8629472ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### What Does This PR Add/Change?

After playing around with the real reporting data, I felt like our current description match logic (just any single token needs to match) was a _bit_ too generous -- you can get a **lot** of hits sometimes, and they aren't all meaningful!

So, to help with that, I made two changes...
1. I migrated our stop word filtering to the library `[stopword](https://www.npmjs.com/package/stopword)` -- it's a bit more comprehensive than our current list, and is now one less thing for us to maintain! 🎉 
2. We now have a stricter threshold to clear. The ratio of (**the total number of hits in the description**) / (**the number of meaningful tokens in the search term**) must be >= **0.6 (60%).**

Why did that I take that approach? Several notes...

- It's common practice to use a ratio threshold in these kinds of searches. This allows the amount to scale with the length of the search.
- I specifically wanted the case where if you used two search terms, you needed two search hits, but I didn't want to overshoot too far, which pushed me to 0.6.
- I wanted to use total hits in the numerator in case a word comes up a lot in the description
- I wanted to use meaningful words in the denominator so that stop words don't artificially inflate the requirements and make things too strict

#### Testing Instructions

Unit tests should still pass!

Best way to test is to use a semi-realistic reporting config locally `REACT_APP_REPORTING_CONFIG_NAME='realistic-config' yarn start`, and just play around and trust your gut! How does it feel? Do we need to pull back or push further?

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #