### PR TITLE
Clicking task links should only ever complete tasks

### DIFF
--- a/src/next-steps/__tests__/task.test.tsx
+++ b/src/next-steps/__tests__/task.test.tsx
@@ -399,5 +399,28 @@ describe( '[Task]', () => {
 				linkType: 'general',
 			} );
 		} );
+
+		test( 'Clicking on a link when the checkbox is checked does not change anything', async () => {
+			const title = 'Foo task';
+			const task: Task = {
+				id: 'general link',
+				parentId: 'foo',
+				parentType: 'product',
+				title: title,
+				link: {
+					type: 'general',
+					href: 'https://automattic.com/',
+				},
+			};
+			const linkName = 'General';
+
+			const { user } = setup( <TaskComponent taskId={ task.id } />, task );
+
+			await user.click( screen.getByRole( 'checkbox', { name: title, checked: false } ) );
+			fireEvent.click( screen.getByRole( 'link', { name: linkName } ) );
+
+			// Still checked
+			expect( screen.getByRole( 'checkbox', { name: title, checked: true } ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/src/next-steps/sub-components/task.tsx
+++ b/src/next-steps/sub-components/task.tsx
@@ -56,16 +56,20 @@ export function Task( { taskId }: Props ) {
 		selectorToPredictCompletingAllTasks( state, taskId )
 	);
 
-	const handleCheckboxChange = () => {
+	const completeTask = () => {
+		dispatch( addCompletedTask( taskId ) );
+		monitoringClient.analytics.recordEvent( 'task_complete' );
+
+		if ( taskCompletionWillCompleteAll ) {
+			monitoringClient.analytics.recordEvent( 'task_complete_all' );
+		}
+	};
+
+	const handleCheckboxToggle = () => {
 		if ( isChecked ) {
 			dispatch( removeCompletedTask( taskId ) );
 		} else {
-			dispatch( addCompletedTask( taskId ) );
-			monitoringClient.analytics.recordEvent( 'task_complete' );
-
-			if ( taskCompletionWillCompleteAll ) {
-				monitoringClient.analytics.recordEvent( 'task_complete_all' );
-			}
+			completeTask();
 		}
 		dispatch( updateHistoryWithState() );
 	};
@@ -83,7 +87,10 @@ export function Task( { taskId }: Props ) {
 	if ( link ) {
 		const handleLinkClick = () => {
 			monitoringClient.analytics.recordEvent( 'task_link_click', { linkType: link.type } );
-			handleCheckboxChange();
+			if ( ! isChecked ) {
+				completeTask();
+				dispatch( updateHistoryWithState() );
+			}
 		};
 
 		try {
@@ -139,7 +146,7 @@ export function Task( { taskId }: Props ) {
 			<label className={ styles.task }>
 				<input
 					className={ styles.taskCheckbox }
-					onChange={ handleCheckboxChange }
+					onChange={ handleCheckboxToggle }
 					checked={ isChecked }
 					type="checkbox"
 				/>


### PR DESCRIPTION
#### What Does This PR Add/Change?

Previously, click a task link would toggle the checkbox, but that doesn't make sense! If the checkbox is checked, and you follow the link, we shouldn't mark the task as incomplete!

Now, clicking links can only complete tasks.

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

*

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #