### PR TITLE
Rename general task links as "Link" for display title

### DIFF
--- a/src/next-steps/__tests__/task.test.tsx
+++ b/src/next-steps/__tests__/task.test.tsx
@@ -198,7 +198,7 @@ describe( '[Task]', () => {
 						href: href,
 					},
 				};
-				const linkName = 'General';
+				const linkName = 'Link';
 
 				setup( <TaskComponent taskId={ task.id } />, task );
 
@@ -279,7 +279,7 @@ describe( '[Task]', () => {
 				};
 
 				setup( <TaskComponent taskId={ task.id } />, task );
-				const link = screen.getByRole( 'link', { name: 'General' } );
+				const link = screen.getByRole( 'link', { name: 'Link' } );
 				expect( link ).toHaveAttribute( 'href', href );
 				expect( link ).toBeInTheDocument();
 			} );
@@ -363,7 +363,7 @@ describe( '[Task]', () => {
 					href: 'https://automattic.com/',
 				},
 			};
-			const linkName = 'General';
+			const linkName = 'Link';
 
 			setup( <TaskComponent taskId={ task.id } />, task );
 
@@ -387,7 +387,7 @@ describe( '[Task]', () => {
 					href: 'https://automattic.com/',
 				},
 			};
-			const linkName = 'General';
+			const linkName = 'Link';
 
 			const { monitoringClient } = setup( <TaskComponent taskId={ task.id } />, task );
 
@@ -412,7 +412,7 @@ describe( '[Task]', () => {
 					href: 'https://automattic.com/',
 				},
 			};
-			const linkName = 'General';
+			const linkName = 'Link';
 
 			const { user } = setup( <TaskComponent taskId={ task.id } />, task );
 

--- a/src/next-steps/sub-components/task.tsx
+++ b/src/next-steps/sub-components/task.tsx
@@ -197,7 +197,7 @@ function getAppIconForLink( link: TaskLink ): ReactNode {
 function getLinkName( link: TaskLink ): string {
 	switch ( link.type ) {
 		case 'general':
-			return 'General';
+			return 'Link';
 		case 'github':
 			return 'GitHub';
 		case 'jira':


### PR DESCRIPTION
#### What Does This PR Add/Change?

The old link title said "General", which doesn't really mean anything to issue reporters. Now, it says "link", making it's purpose more clear!

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

*

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #