### PR TITLE
Improve the default titles for general and jira link tasks

### DIFF
--- a/public/local-reporting-configs/default.json
+++ b/public/local-reporting-configs/default.json
@@ -66,6 +66,12 @@
 					"bug": [
 						{
 							"details": "Feature Group | Bug | details only"
+						},
+						{
+							"link": {
+								"type": "general",
+								"href": "https://google.com/search?q=feature-group"
+							}
 						}
 					],
 					"featureRequest": [

--- a/src/next-steps/__tests__/task.test.tsx
+++ b/src/next-steps/__tests__/task.test.tsx
@@ -287,6 +287,28 @@ describe( '[Task]', () => {
 				const link = screen.getByRole( 'link', { name: 'Link' } );
 				expect( link ).toHaveAttribute( 'href', href );
 				expect( link ).toBeInTheDocument();
+				expect(
+					screen.getByRole( 'checkbox', { name: 'Click the link to report your issue' } )
+				).toBeInTheDocument();
+			} );
+
+			test( 'Jira link task', () => {
+				const task: Task = {
+					id: 'jira',
+					parentId: 'foo',
+					parentType: 'product',
+					link: {
+						type: 'jira',
+						hostName: 'fake.atlasssian.net',
+						projectId: 12345,
+						issueTypeId: 54321,
+					},
+				};
+
+				setup( <TaskComponent taskId={ task.id } />, task );
+				expect(
+					screen.getByRole( 'checkbox', { name: 'Click the link to open a new Jira issue' } )
+				).toBeInTheDocument();
 			} );
 
 			test( 'Task with no link and no title', () => {

--- a/src/next-steps/sub-components/task.tsx
+++ b/src/next-steps/sub-components/task.tsx
@@ -164,11 +164,11 @@ export function Task( { taskId }: Props ) {
 function getDefaultTitleForLink( link: TaskLink ): string {
 	switch ( link.type ) {
 		case 'general':
-			return link.href;
+			return 'Click the link to report your issue';
 		case 'github':
 			return `Click the link to open your report in the ${ link.repository } repo`;
 		case `jira`:
-			return 'Open a new issue';
+			return 'Click the link to open a new Jira issue';
 		case 'slack':
 			return `Notify the #${ link.channel } channel in Slack`;
 		case 'p2':


### PR DESCRIPTION
#### What Does This PR Add/Change?

Adds better default titles for tasks that have general or jira links, and no title

#### Testing Instructions


#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #