### PR TITLE
Tree performance round 1: just rebuild the whole thing on search

### DIFF
--- a/src/feature-selector-form/sub-components/feature-selector-tree.tsx
+++ b/src/feature-selector-form/sub-components/feature-selector-tree.tsx
@@ -41,6 +41,12 @@ export function FeatureSelectorTree( { parentElementId }: Props ) {
 		);
 	}
 
+	// Keying the whole list actually provides us a pretty big performance benefit when rendering the tree.
+	// Reconciling the DOM after a search when you have a big tree expanded is really slow.
+	// It's actually almost always faster to just throw away the whole tree and rebuild it based on the new search results.
+	// We already reset the UI for the user, so just rebuilding the whole tree doesn't change the user experience at all!
+	const listKey = `search-${ searchTerm }`;
+
 	return (
 		<div className={ styles.treeWrapper }>
 			<fieldset className={ styles.treeFieldset } id={ parentElementId }>
@@ -48,7 +54,7 @@ export function FeatureSelectorTree( { parentElementId }: Props ) {
 				<legend className="screenReaderOnly">
 					Expandable and collapsible tree with products, feature groups, and features
 				</legend>
-				<SortedProductList productIds={ productsToDisplay } />
+				<SortedProductList key={ listKey } productIds={ productsToDisplay } />
 			</fieldset>
 		</div>
 	);


### PR DESCRIPTION
#### What Does This PR Add/Change?

This is a round 1 of performance improvements to the features selection tree.

Simply put, reconciling changes to a large tree (lots of items expanded) on a new search term is reallllly slow.

It's almost always faster to just rebuild the whole tree from scratch!

To do that, we key the tree off of the search term. That forces a rebuild on every search update

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

If you expand everything, then do a search (like "Word"), things should be way faster now!

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #134 
Closes #