### PR TITLE
Tree Performance Round 2: Add character limit for feature search

### DIFF
--- a/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
@@ -372,5 +372,32 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 				screen.getByText( 'No results found. Try a different search or explore manually below.' )
 			).toBeInTheDocument();
 		} );
+
+		test( "If you search for only white space, it doesn't search", async () => {
+			const { user } = setup( <FeatureSelectorForm /> );
+			await search( user, ' ' );
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'ABC Product' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'PQR Product' } )
+			).toBeInTheDocument();
+		} );
+
+		test( "If you clear the field, it doesn't search again", async () => {
+			const { user } = setup( <FeatureSelectorForm /> );
+
+			await search( user, 'abc' );
+
+			await user.clear( screen.getByRole( 'textbox', { name: 'Search for a feature' } ) );
+			await user.keyboard( '{Enter}' );
+
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'ABC Product' } )
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', { expanded: false, name: 'PQR Product' } )
+			).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
+++ b/src/feature-selector-form/__tests__/feature-selector-search.test.tsx
@@ -384,12 +384,15 @@ describe( '[FeatureSelector -- Tree interaction]', () => {
 			).toBeInTheDocument();
 		} );
 
-		test( "If you clear the field, it doesn't search again", async () => {
+		test( 'Clearing the field only resets the results after pressing enter', async () => {
 			const { user } = setup( <FeatureSelectorForm /> );
 
 			await search( user, 'abc' );
 
 			await user.clear( screen.getByRole( 'textbox', { name: 'Search for a feature' } ) );
+
+			expect( screen.getByText( 'Results found. Search results are below.' ) ).toBeInTheDocument();
+
 			await user.keyboard( '{Enter}' );
 
 			expect(

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -105,7 +105,7 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 					placeholder='Search for a feature (e.g. "site editor") '
 					inputAriaLabel="Search for a feature"
 					inputAriaControls={ searchControlsId }
-					debounceMs={ 500 }
+					debounceMs={ 300 }
 					debounceCharacterMinimum={ 3 }
 				/>
 			</div>

--- a/src/feature-selector-form/feature-selector-form.tsx
+++ b/src/feature-selector-form/feature-selector-form.tsx
@@ -105,6 +105,8 @@ export function FeatureSelectorForm( { onContinue }: Props ) {
 					placeholder='Search for a feature (e.g. "site editor") '
 					inputAriaLabel="Search for a feature"
 					inputAriaControls={ searchControlsId }
+					debounceMs={ 500 }
+					debounceCharacterMinimum={ 3 }
 				/>
 			</div>
 


### PR DESCRIPTION
#### What Does This PR Add/Change?

This is part of optimizing the performance of the feature search. 

When searching for a feature, **there is now a minimum of 3 characters to trigger the search.** The behavior is similar when searching for issues:

- you will need to press enter to bypass debouncing
- if the search term is empty, it will not trigger a search

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

- Make sure all tests passed 
- A search term with 3 characters should trigger the search. Check that the text highlight is still working as expected 

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #134 
Closes #