### PR TITLE
Feature Tree Performance Round 3: One Tooltip component for the whole tree

### DIFF
--- a/src/feature-selector-form/sub-components/expandable-tree-node.tsx
+++ b/src/feature-selector-form/sub-components/expandable-tree-node.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react';
 import styles from './../feature-selector-form.module.css';
 import { ReactComponent as CollapsedIcon } from '../../common/svgs/chevron-right.svg';
 import { ReactComponent as ExpandedIcon } from '../../common/svgs/chevron-down.svg';
-import { Tooltip } from 'react-tooltip';
 
 interface Props {
 	children: ReactNode;
@@ -24,7 +23,6 @@ export function ExpandableTreeNode( {
 	// If needed in the future, we can crawl the label for text content and add that.
 	const randomString = Math.random().toString( 16 ).slice( 2 );
 	const contentId = `expandable-tree-node-content_${ randomString }`;
-	const labelId = `expandable-tree-node-label_${ randomString }`;
 	const descriptionId = `expandable-tree-node-description_${ randomString }`;
 
 	let icon: React.ReactNode;
@@ -45,17 +43,14 @@ export function ExpandableTreeNode( {
 				aria-describedby={ descriptionId }
 			>
 				{ icon }
-				<span id={ labelId } className={ styles.treeNodeContentWrapper }>
+				<span
+					className={ styles.treeNodeContentWrapper }
+					data-tooltip-id="feature-tree-tooltip"
+					data-tooltip-content={ description }
+				>
 					{ label }
 				</span>
 			</button>
-			<Tooltip
-				anchorSelect={ `#${ labelId }` }
-				delayShow={ 1000 }
-				className={ styles.tooltip }
-				content={ description }
-				place="right"
-			/>
 			<span hidden={ true } id={ descriptionId }>
 				{ description }
 			</span>

--- a/src/feature-selector-form/sub-components/feature-selector-tree.tsx
+++ b/src/feature-selector-form/sub-components/feature-selector-tree.tsx
@@ -5,6 +5,7 @@ import { selectNormalizedReportingConfig } from '../../static-data/reporting-con
 import { selectFeatureSearchTerm } from '../feature-selector-form-slice';
 import styles from '../feature-selector-form.module.css';
 import { SortedProductList } from './sorted-product-list';
+import { Tooltip } from 'react-tooltip';
 
 interface Props {
 	parentElementId: string;
@@ -54,6 +55,12 @@ export function FeatureSelectorTree( { parentElementId }: Props ) {
 				<legend className="screenReaderOnly">
 					Expandable and collapsible tree with products, feature groups, and features
 				</legend>
+				<Tooltip
+					delayShow={ 1000 }
+					className={ styles.tooltip }
+					place="right"
+					id="feature-tree-tooltip"
+				/>
 				<SortedProductList key={ listKey } productIds={ productsToDisplay } />
 			</fieldset>
 		</div>

--- a/src/feature-selector-form/sub-components/feature.tsx
+++ b/src/feature-selector-form/sub-components/feature.tsx
@@ -9,7 +9,6 @@ import { selectSelectedFeatureId, setSelectedFeatureId } from '../feature-select
 import { replaceSpaces } from '../../common/lib';
 import { SearchHighlighter } from './search-hightlighter';
 import { useMonitoring } from '../../monitoring/monitoring-provider';
-import { Tooltip } from 'react-tooltip';
 import { MatchedTypeDisplay } from './matched-terms-display';
 
 interface Props {
@@ -36,7 +35,6 @@ export function Feature( { id }: Props ) {
 	const matchedDisplay = <MatchedTypeDisplay entityId={ id } entityType={ 'features' } />;
 
 	const safeId = replaceSpaces( id );
-	const featureNameId = `feature_name_${ safeId }`;
 	const descriptionId = `description_${ safeId }`;
 
 	return (
@@ -49,7 +47,11 @@ export function Feature( { id }: Props ) {
 				onClick={ handleFeatureSelect }
 				aria-describedby={ descriptionId }
 			>
-				<span id={ featureNameId } className={ styles.treeNodeContentWrapper }>
+				<span
+					className={ styles.treeNodeContentWrapper }
+					data-tooltip-id="feature-tree-tooltip"
+					data-tooltip-content={ description }
+				>
 					<span>
 						<SearchHighlighter>{ featureName }</SearchHighlighter>
 					</span>
@@ -57,14 +59,6 @@ export function Feature( { id }: Props ) {
 				</span>
 			</button>
 
-			<Tooltip
-				// Can't use #ID because some characters in IDs may not be safe for that syntax.
-				anchorSelect={ `[id='${ featureNameId }']` }
-				delayShow={ 1000 }
-				className={ styles.tooltip }
-				content={ description }
-				place="right"
-			/>
 			<span hidden={ true } id={ descriptionId }>
 				{ description }
 			</span>


### PR DESCRIPTION
#### What Does This PR Add/Change?

Now we use just one `Tooltip` component for the whole tree, and use the data attributes instead to populate that tooltip.

In profiles, the Tooltip was showing up as one of the more expensive components, so this should improve things!

And sure enough, it decreased the React commit phase time by about 300%! In my tests, that phase went on average from about ~150ms to ~50ms 🚀 

#### Testing Instructions

<!--
Give clear instructions, maybe even a checklist, for how to test the changes.
-->

*

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #