### PR TITLE
Make all localstorage caches error safe

### DIFF
--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -37,8 +37,8 @@ class ProductionApiClient implements ApiClient, LoggerApiClient {
 			const data = await response.json();
 
 			const cacheExpiryTime = Date.now() + 3 * 24 * 60 * 60 * 1000; // 3 days in milliseconds
-			localStorage.setItem( 'cachedReportingConfigData', JSON.stringify( data ) );
-			localStorage.setItem( 'cacheExpiry', cacheExpiryTime.toString() );
+			safelySetLocalstorageCache( 'cachedReportingConfigData', JSON.stringify( data ) );
+			safelySetLocalstorageCache( 'cacheExpiry', cacheExpiryTime.toString() );
 
 			return data;
 		} else {
@@ -95,8 +95,8 @@ class ProductionApiClient implements ApiClient, LoggerApiClient {
 
 			const newCacheExpiry = Date.now() + 14 * 24 * 60 * 60 * 1000; // 14 days -- these really won't change often
 
-			localStorage.setItem( repoFiltersCacheKey, JSON.stringify( repoFilters ) );
-			localStorage.setItem( repoFiltersCacheExpiryKey, newCacheExpiry.toString() );
+			safelySetLocalstorageCache( repoFiltersCacheKey, JSON.stringify( repoFilters ) );
+			safelySetLocalstorageCache( repoFiltersCacheExpiryKey, newCacheExpiry.toString() );
 
 			return repoFilters;
 		} else {
@@ -163,4 +163,19 @@ export function createProductionApiClient(): ApiClient & LoggerApiClient {
 			productionApiClient.loadAvailableRepoFilters.bind( productionApiClient ),
 		searchIssues: productionApiClient.searchIssues.bind( productionApiClient ),
 	};
+}
+
+function safelySetLocalstorageCache( key: string, value: string ) {
+	try {
+		localStorage.setItem( key, value );
+	} catch ( err ) {
+		// Caching should never bubble up errors -- it's just a performance optimization!
+		// The most likely thing we'd hit when caching is a QuotaExceededError.
+		// So let's just leave a gentle console message about the user being able to add a perfomrance boost.
+		console.info(
+			`Unable to set cache value for ${ key }. ` +
+				`This likely means there is too much in localstorage for this domain. ` +
+				`Consider deleting unused data from localstorage -- it will speed up performance on this site! `
+		);
+	}
 }

--- a/src/api/production-api-client.ts
+++ b/src/api/production-api-client.ts
@@ -174,7 +174,7 @@ function safelySetLocalstorageCache( key: string, value: string ) {
 		// So let's just leave a gentle console message about the user being able to add a perfomrance boost.
 		console.info(
 			`Unable to set cache value for ${ key }. ` +
-				`This likely means there is too much in localstorage for this domain. ` +
+				`This likely means there is too much in localstorage for this website. ` +
 				`Consider deleting unused data from localstorage -- it will speed up performance on this site! `
 		);
 	}


### PR DESCRIPTION
#### What Does This PR Add/Change?

All our localstorage cache sets are now error safe, meaning a failure to cache will never disrupt site usage.

Now, we just leave a helpful console message that the user might be able to speed up the site by making some room in localstorage

#### Testing Instructions

This has to be tested on an internal deployment to use the real API -- I've taken care of that! I deployed on my sandbox and inflated local storage so there was no room, and verified all 4 keys don't throw errors and leave the console message.

Also, all unit tests are passing!

#### Issues

<!--
Link related issues or issues that this PR fixes/closes
-->

Related to #  
Closes #147 