### PR TITLE
Prevent global style overrides

### DIFF
--- a/src/feature-selector-form/feature-selector-form.module.css
+++ b/src/feature-selector-form/feature-selector-form.module.css
@@ -62,6 +62,11 @@ button.treeNode {
 
 button.treeNode:hover {
 	background-color: var( --color-primary-lightest );
+	color: var( --color-text );
+}
+
+button.treeNode:focus {
+	outline: none;
 }
 
 .treeNodeContentWrapper {


### PR DESCRIPTION
Specifically, this fixes some A-Train MC styles from bleeding into Bugomattic.

#### What Does This PR Add/Change?

* Prevent global style overrides in the list.

Before:
<img width="775" alt="Screenshot 2024-09-02 at 09 25 37" src="https://github.com/user-attachments/assets/d759f37a-a8ee-41be-8a5b-5fa2a134a9a5">

After:
<img width="770" alt="Screenshot 2024-09-02 at 09 25 44" src="https://github.com/user-attachments/assets/23d642f6-d19b-41ab-879e-6e76aea80c12">


#### Testing Instructions

Best to build the production bundle, upload it to your WPCOM sandbox and verify that it works as expected in the MC environment. There should be no change for non-MC environments.
