### PR TITLE
GitHub reporting: add support for GH Enterprise

### DIFF
--- a/public/local-reporting-configs/default.json
+++ b/public/local-reporting-configs/default.json
@@ -97,7 +97,7 @@
 				"features": {
 					"Feature (Under Feature Group)": {
 						"description": "Feature (Under Feature Group) description",
-						"keywords": [ "foo", "bar" ],
+						"keywords": ["foo", "bar"],
 						"learnMoreLinks": [
 							{
 								"type": "p2",
@@ -120,8 +120,8 @@
 									"link": {
 										"type": "github",
 										"repository": "Automattic/fake-repo",
-										"labels": [ "[Type] Bug" ],
-										"projectSlugs": [ "[Automattic/12345]" ]
+										"labels": ["[Type] Bug"],
+										"projectSlugs": ["[Automattic/12345]"]
 									}
 								}
 							],
@@ -131,8 +131,8 @@
 									"link": {
 										"type": "github",
 										"repository": "Automattic/fake-repo",
-										"labels": [ "[Type] Feature Request" ],
-										"projectSlugs": [ "[Automattic/12345]" ]
+										"labels": ["[Type] Feature Request"],
+										"projectSlugs": ["[Automattic/12345]"]
 									}
 								}
 							],
@@ -142,8 +142,72 @@
 									"link": {
 										"type": "github",
 										"repository": "Automattic/fake-repo",
-										"labels": [ "[Type] Bug", "[Pri] BLOCKER" ],
-										"projectSlugs": [ "[Automattic/12345]" ]
+										"labels": ["[Type] Bug", "[Pri] BLOCKER"],
+										"projectSlugs": ["[Automattic/12345]"]
+									}
+								},
+								{
+									"details": "Duplicate Task | P2 link",
+									"link": {
+										"type": "p2",
+										"subdomain": "duplicate"
+									}
+								}
+							]
+						}
+					},
+					"Feature in GitHub enterprise (Under Feature Group)": {
+						"description": "Feature in GitHub enterprise (Under Feature Group) description",
+						"keywords": ["github", "enterprise"],
+						"learnMoreLinks": [
+							{
+								"type": "p2",
+								"subdomain": "feature-under-feature-group"
+							},
+							{
+								"type": "slack",
+								"channel": "feature-under-feature-group"
+							},
+							{
+								"type": "general",
+								"href": "https://google.com/search?q=feature-under-feature-group"
+							}
+						],
+						"tasks": {
+							"bug": [
+								{
+									"title": "Testing a really really really really super super super super duper very much look how long it is it just keeps going dear god long link",
+									"details": "Feature (Under Feature Group) | Bug | GitHub link",
+									"link": {
+										"type": "github",
+										"org": "fake",
+										"repository": "Automattic/fake-repo",
+										"labels": ["[Type] Bug"],
+										"projectSlugs": ["[Automattic/12345]"]
+									}
+								}
+							],
+							"featureRequest": [
+								{
+									"details": "Feature (Under Feature Group) | Feature Request | GitHub link",
+									"link": {
+										"type": "github",
+										"org": "fake",
+										"repository": "Automattic/fake-repo",
+										"labels": ["[Type] Feature Request"],
+										"projectSlugs": ["[Automattic/12345]"]
+									}
+								}
+							],
+							"urgent": [
+								{
+									"details": "Feature (Under Feature Group) | Urgent | GitHub link",
+									"link": {
+										"type": "github",
+										"org": "fake",
+										"repository": "Automattic/fake-repo",
+										"labels": ["[Type] Bug", "[Pri] BLOCKER"],
+										"projectSlugs": ["[Automattic/12345]"]
 									}
 								},
 								{

--- a/src/common/lib/__tests__/links.test.ts
+++ b/src/common/lib/__tests__/links.test.ts
@@ -102,6 +102,27 @@ describe( '[Links]', () => {
 			).toBe( expectedHref );
 		} );
 
+		test( 'If an org is provided, uses it to customize the URL', () => {
+			const expectedHref = 'https://github.a8c.com/Automattic/wpcom/issues/new/choose';
+			expect(
+				createNewGithubIssueHref( {
+					type: 'github',
+					repository: 'Automattic/wpcom',
+					org: 'a8c',
+				} )
+			).toBe( expectedHref );
+		} );
+
+		test( 'If no org is provided, uses the default GitHub URL', () => {
+			const expectedHref = 'https://github.com/Automattic/bugomattic/issues/new/choose';
+			expect(
+				createNewGithubIssueHref( {
+					type: 'github',
+					repository: 'Automattic/bugomattic',
+				} )
+			).toBe( expectedHref );
+		} );
+
 		test( 'If no GitHub params are provided, ends route at /new/choose', () => {
 			const expectedHref = 'https://github.com/Automattic/bugomattic/issues/new/choose';
 			expect(

--- a/src/common/lib/links.ts
+++ b/src/common/lib/links.ts
@@ -41,7 +41,13 @@ export function createNewGithubIssueHref( link: NewGitHubIssueLink, issueTitle?:
 	// For safety, we don't really need to validate all the individual pieces here.
 	// As long as we use the URL API and guarantee the root GitHub domain, we are safe.
 	// Any broken pieces will just result in a Github 404 or the param being tossed out by Github.
-	const url = new URL( 'https://github.com' );
+	let url = new URL( 'https://github.com' );
+
+	// If one specifies an org, let's customize the URL accordingly.
+	if ( link.org ) {
+		url = new URL( `https://github.${ link.org }.com` );
+	}
+
 	let pathEnd = 'new';
 	if (
 		( ! link.labels || link.labels.length === 0 ) &&

--- a/src/static-data/reporting-config/types.ts
+++ b/src/static-data/reporting-config/types.ts
@@ -112,6 +112,7 @@ export interface NewGitHubIssueLink {
 	template?: string; // "bug_report.yml" e.g.
 	projectSlugs?: string[]; // "Automattic/xyz" e.g.
 	labels?: string[]; // "[Pri] High" e.g.
+	org?: string; // "a8c" e.g.
 }
 
 export interface NewJiraIssueLink {


### PR DESCRIPTION
#### What Does This PR Add/Change?

It adds a new "org" option when specifying a GitHub configuration.

By specifying a new "org" parameter, one can specify GitHub enterprise links for bug reports and feature requests.

#### Testing Instructions

* Check out this branch.
* Run `yarn start`
* In the local setup of Bugomattic that opens, set to report a bug, then search for "enterprise".
* Click on the reporting link that is offered to you.
    * It should open `https://github.fake.com/Automattic/fake-repo/issues/new?`

#### Issues

Internal reference: p1739871676757909-slack-C029GN3KD
Previous reference: pNEWy-iDc-p2#comment-57537
