### PR TITLE
Linear: add option to specify a project

### DIFF
--- a/public/local-reporting-configs/default.json
+++ b/public/local-reporting-configs/default.json
@@ -370,6 +370,49 @@
 							]
 						},
 						"keywords": [ "mdr", "lumon" ]
+					},
+					"Linear Project Feature": {
+						"description": "A feature tracked in Linear under a specific project",
+						"keywords": ["linear", "project", "calypso"],
+						"tasks": {
+							"bug": [
+								{
+									"details": "Linear Project Feature | Bug | Linear link",
+									"link": {
+										"type": "linear",
+										"workspace": "a8c",
+										"team": "calypso",
+										"project": "linear-feature-123",
+										"labels": [ "[Type] Bug" ]
+									}
+								}
+							],
+							"featureRequest": [
+								{
+									"details": "Linear Project Feature | Feature Request | Linear link",
+									"link": {
+										"type": "linear",
+										"workspace": "a8c",
+										"team": "calypso",
+										"project": "linear-feature-123",
+										"template": "1234567890"
+									}
+								}
+							],
+							"urgent": [
+								{
+									"details": "Linear Project Feature | Urgent bug | Linear link",
+									"link": {
+										"type": "linear",
+										"workspace": "a8c",
+										"team": "calypso",
+										"project": "linear-feature-123",
+										"priority": "urgent",
+										"labels": [ "[Type] Bug" ]
+									}
+								}
+							]
+						}
 					}
 				}
 			}

--- a/src/common/lib/__tests__/links.test.ts
+++ b/src/common/lib/__tests__/links.test.ts
@@ -221,6 +221,25 @@ describe( '[Links]', () => {
 			).toBe( expectedHref );
 		} );
 
+		test( 'When both a team and a project are provided, the URL points to the project', () => {
+			const expectedHref = 'https://linear.app/workspace/project/123/new';
+			expect(
+				createNewLinearIssueHref( {
+					type: 'linear',
+					workspace: 'workspace',
+					team: 'calypso',
+					project: '123',
+				} )
+			).toBe( expectedHref );
+		} );
+
+		test( 'When only a project is provided, without a team, it is not added to the URL', () => {
+			const expectedHref = 'https://linear.app/workspace/new';
+			expect(
+				createNewLinearIssueHref( { type: 'linear', workspace: 'workspace', project: '123' } )
+			).toBe( expectedHref );
+		} );
+
 		test( 'If an issue title is provided, adds and encodes query param for it', () => {
 			const expectedHref = 'https://linear.app/new?title=foo%26bar';
 			expect( createNewLinearIssueHref( { type: 'linear' }, 'foo&bar' ) ).toBe( expectedHref );

--- a/src/common/lib/links.ts
+++ b/src/common/lib/links.ts
@@ -92,11 +92,21 @@ export function createNewJiraIssueHref( link: NewJiraIssueLink ) {
 }
 
 export function createNewLinearIssueHref( link: NewLinearIssueLink, issueTitle?: string ) {
-	const url = new URL(
+	let url = new URL(
 		`https://linear.app/${ link.workspace ? `${ link.workspace }/` : '' }${
 			link.team ? `team/${ link.team }/` : ''
 		}new`
 	);
+
+	// Project links will only work if a team is also provided.
+	// If both a team and a project are provided, we'll update the URL to point to the project.
+	if ( link.team && link.project ) {
+		url = new URL(
+			`https://linear.app/${ link.workspace ? `${ link.workspace }/` : '' }project/${
+				link.project
+			}/new`
+		);
+	}
 
 	if ( issueTitle ) {
 		url.searchParams.append( 'title', issueTitle );

--- a/src/static-data/reporting-config/types.ts
+++ b/src/static-data/reporting-config/types.ts
@@ -123,6 +123,7 @@ export interface NewLinearIssueLink {
 	priority?: string; // Possible values are high, urgent, medium and low.
 	labels?: string[]; // Label names. Must match existing labels in Linear, or will be ignored.
 	template?: string; // UUID of the issue template.
+	project?: string; // UUID of the project.
 }
 
 export interface NewJiraIssueLink {


### PR DESCRIPTION
#### What Does This PR Add/Change?

When using the `linear` type, you can now specify a specific project for issues.

Note: when specifying a project, you also need to specify a team for it.
See https://developers.linear.app/docs/guides/how-to-create-new-issues-using-linear.new#project

#### Testing Instructions

* Is CI happy?
* Check "Linear Project Feature" feature in the test data

#### Issues

Internal reference: p7DVsv-mMD-p2